### PR TITLE
SC-47867 Add Analytics Endpoint Skills

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -83,8 +83,19 @@ Invoke it when another skill surfaces a failure that points to one of the condit
 - "Explain rule javascript:S1234"
 - "What metrics are available?"
 - "Show me code complexity metrics"
+- "Graph coverage for main over 90 days"
+- "What is the quality gate ratio for this portfolio?"
+- "Which projects currently have unresolved vulnerabilities?"
 
-**What to do:** No dedicated skill exists for this — call the MCP tools directly: `mcp__sonarqube__show_rule` for rule explanations, `mcp__sonarqube__search_metrics` for available metrics, and `mcp__sonarqube__get_component_measures` for specific metric values.
+**What to do:** For rule explanations, call `mcp__sonarqube__show_rule` directly. For generic metric-catalog requests such as "What metrics are available?" or "Show me code complexity metrics", call `mcp__sonarqube__search_metrics` directly.
+
+- For ambiguous analytics-discovery requests that need routing among the measure skills, start with `sonar-measures` as the router skill.
+- If the request already clearly asks for trend history, issue-count history, current portfolio aggregate measures, or issue inspection, bypass `sonar-measures` and invoke the concrete skill directly.
+- For project-branch or portfolio metric trend history, invoke `sonar-measures-history`.
+- For project-branch or portfolio issue count trend history, invoke `sonar-issue-count-history`.
+- For current portfolio aggregate measures from `/enterprises/portfolio-measures` such as quality-gate ratio, releasability rating, or project-branch counts, invoke `sonar-portfolio-measures`.
+- For portfolio membership, per-project rankings, top-N projects inside a portfolio, or other portfolio drilldown beyond current aggregate measures, do not route to `sonar-portfolio-measures`; no current skill owns that flow.
+- For current issue inspection such as unresolved vulnerabilities or severity/type searches, invoke `sonar-list-issues`.
 
 ## Important Parameter Guidelines
 

--- a/skills/sonar-issue-count-history/SKILL.md
+++ b/skills/sonar-issue-count-history/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: sonar-issue-count-history
+description: Fetch SonarQube project, branch, or portfolio issue count trend history via sonarqube-cli across organizations issue-count-history endpoints
+argument-hint: "(project <project-key>|<project-name> [--branch name]) | (portfolio <portfolio-id>|<portfolio-name>) [--start yyyy-mm-dd] [--end yyyy-mm-dd] [--slice-by field] [--impact value[,value...]] [--type value[,value...]] [--rule value[,value...]] [--severity value[,value...]] [--status value[,value...]]"
+allowed-tools: Read, Grep, Bash(sonar:*)
+---
+
+# SonarQube - Issue Count History
+
+Use this skill for project, branch, or portfolio issue count trend history when the answer should come from Sonar issue-count-history endpoints.
+
+This skill covers:
+
+- issue count history over time
+- project key/name, branchId, and portfolio UUID resolution for history queries
+- optional issue-series segmentation and filter mapping
+- time-series formatting guidance
+
+## Usage
+
+```
+sonar-issue-count-history my-project --start 2026-04-28
+sonar-issue-count-history "My Project Name" --start 2026-04-28
+sonar-issue-count-history my-project --branch release/2.0 --start 2026-04-28 --end 2026-05-28
+sonar-issue-count-history my-project --start 2026-04-28 --slice-by TYPE --type BUG,VULNERABILITY
+sonar-issue-count-history --portfolio-id 123e4567-e89b-12d3-a456-426614174000 --start 2026-04-28 --slice-by SEVERITY
+sonar-issue-count-history --portfolio-name "Code Orchestration" --start 2026-04-28 --severity BLOCKER,HIGH
+```
+
+Representative user requests this skill should handle:
+
+- "Show me issue count over the last month."
+- "Graph bug counts for main this quarter."
+- "How have critical issues changed over the last 30 days?"
+- "Show severity trends for the Finance portfolio."
+
+## Command selection
+
+Use the command that matches the current stage of the workflow:
+
+- Project name input: resolve the exact project key with `sonar list projects --query <PROJECT_NAME>`.
+- Project key input: resolve the branch entry with `sonar api GET "/api/project_branches/list?project=<PROJECT_KEY>"` and use its `branchId` as `entityId`.
+- Portfolio name input: resolve enterprise and portfolio IDs with `sonar api GET` against the enterprise endpoints.
+- History fetch: use `sonar api GET "/organizations/issue-count-history?..."`
+
+Do not stay in "raw API mode" for every step just because the final history call uses `sonar api GET`.
+Project-name resolution should use `sonar list projects` first, then switch to `sonar api GET` only for branch/entity resolution and history retrieval.
+
+## Prerequisites
+
+This skill uses the `sonarqube-cli` command. The CLI must be installed and authenticated before proceeding.
+
+This skill also uses endpoints that are exclusive to SonarQube Cloud for the time being.
+The CLI must be authenticated with a valid SonarQube Cloud instance:
+- `sonarcloud.io`
+- `sonarqube.us`
+
+**Before proceeding**, verify that `sonar` is available on your PATH and authenticated.
+
+If a Sonar command fails because of sandbox, keychain, or local-state problems, retry the same Sonar command with elevated execution before concluding that authentication is broken.
+
+If the elevated retry succeeds, treat `sonar` as requiring elevated execution for the rest of the current task. Run subsequent `sonar` commands elevated instead of retrying each one in the sandbox first.
+
+Operational notes:
+
+- In sandboxed applications `sonar` may print valid JSON and still exit nonzero because of local-state or keychain problems. Inspect stdout before discarding a result when the payload looks complete.
+- Keychain-backed auth may require elevated execution outside the normal sandbox.
+- Typical signals include `Failed to access the system keychain`, credential-manager access failures, and `EPERM` writing under `~/.sonar`.
+- When requesting elevated execution for Sonar API reads, prefer a reusable approval prefix such as `["sonar","api","GET"]` to avoid repeated approval churn.
+
+If `sonar` still is not available or authenticated after the retry, do not attempt to call any alternative commands or invent alternatives, and show the user:
+
+> Unable to fetch Sonar issue-count history data.
+>
+> **Possible causes:**
+> - `sonarqube-cli` not installed or not authenticated - invoke the sonar-integrate skill
+
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then re-check and continue; if they decline, stop.
+
+## Instructions
+
+### Step 1: Resolve the target entity and entity ID
+
+- Require exactly one target scope:
+  - a project key or project name, optionally with `--branch`, for `PROJECT_BRANCH`
+  - or a verified `--portfolio-id` UUID for `PORTFOLIO`
+  - or a `--portfolio-name` that must be resolved to a verified portfolio UUID before continuing
+- If both a project selector and any portfolio selector (`--portfolio-id` or `--portfolio-name`) are supplied, stop and ask the user to choose one scope.
+- If both `--portfolio-id` and `--portfolio-name` are supplied, prefer the verified `--portfolio-id` and use the name only as a consistency check when helpful.
+- Use only verified project keys, branchIds, and portfolio UUIDs from the user or Sonar output.
+
+#### Project scope (`PROJECT_BRANCH`)
+
+- If the user provided a project key directly, validate it against `^[a-zA-Z0-9_\\-\\.:]+$`.
+- If the user provided a project name instead of a key, resolve the exact project key before calling `project_branches/list`.
+- Do not use `sonar api GET "/api/components/search_projects?...` to resolve a project name for this skill.
+- Use `sonar list projects --query <PROJECT_NAME>` for project-name lookup, because that is the intended search flow and has clearer name/key filtering semantics.
+- To resolve a project name, use the same lookup flow as `sonar-list-projects`:
+
+```bash
+sonar list projects --page-size 500 --page <PAGE_NUMBER> --query <PROJECT_NAME>
+```
+
+- Continue paging until the full matching result set has been checked.
+- If the project-name lookup returns multiple plausible projects, ask the user to choose instead of guessing.
+- If the project-name lookup returns no matches, stop and tell the user no project was found rather than falling through to the branch lookup.
+- For `PROJECT_BRANCH`, resolve the project branch entry with:
+
+```bash
+sonar api GET "/api/project_branches/list?project=<PROJECT_KEY>"
+```
+
+- For `PROJECT_BRANCH`, use the branch with `isMain: true` when the user did not specify a branch.
+- For `PROJECT_BRANCH`, use the `branchId` field from the selected branch entry as the `entityId` for `/organizations/issue-count-history`.
+- `branchId` is the preferred UUID-shaped identifier for organizations history calls.
+- Do not use `branchUuidV1`; this skill should use `branchId`.
+- For `PROJECT_BRANCH`, if the user specified a branch, pick the matching branch entry and use its `branchId`.
+
+#### Portfolio scope (`PORTFOLIO`)
+
+- If the user provided only a portfolio name, resolve the enterprise UUID first if needed:
+
+```bash
+sonar api GET "/enterprises/enterprises"
+```
+
+- URL-encode every value interpolated into the request path or query string before issuing the command.
+  - Example: `Code Orchestration` -> `Code%20Orchestration`
+
+- Then look up the portfolio by name:
+
+```bash
+sonar api GET "/enterprises/portfolios?enterpriseId=<ENTERPRISE_UUID>&q=<PORTFOLIO_NAME>"
+```
+
+- Use only a verified portfolio UUID returned by Sonar output.
+- If the lookup returns multiple plausible portfolios, ask the user to choose instead of guessing.
+- Use `entityType=PORTFOLIO` and `entityId=<PORTFOLIO_UUID>` directly after resolution.
+
+### Step 2: Resolve and validate the time range
+
+- Convert relative windows to concrete UTC dates before building commands.
+- Use inclusive UTC calendar semantics for relative windows:
+  - `"last N days"` and `"past N days"` mean exactly `N` daily UTC points ending on the current UTC date.
+  - Compute `startDate = today_utc - (N - 1) days` and `endDate = today_utc`.
+  - `"this month"` means the first day of the current UTC month through the current UTC date.
+  - `"last month"` means the first day of the previous UTC month through the last day of the previous UTC month.
+  - `"this quarter"` means the first day of the current UTC quarter through the current UTC date.
+  - `"last quarter"` means the first day of the previous UTC quarter through the last day of the previous UTC quarter.
+- Worked examples assuming today is `2026-05-29` UTC:
+  - `"last 30 days"` -> `startDate=2026-04-30`, `endDate=2026-05-29`
+  - `"this quarter"` -> `startDate=2026-04-01`, `endDate=2026-05-29`
+  - `"last quarter"` -> `startDate=2026-01-01`, `endDate=2026-03-31`
+- Validate `--start` and `--end` as `YYYY-MM-DD`.
+- `startDate` more than one year in the past is rejected by the organizations history endpoints.
+- If `--end` is omitted, let the endpoint use its default latest bound.
+
+### Step 3: Validate and map issue-count filters
+
+- Use `/organizations/issue-count-history`; do not invent an issue-count metric key.
+- Default to one aggregate line when the user did not request a breakdown.
+- Only pass filters the user explicitly asked for.
+- Preserve the user-supplied value order within each comma-separated filter list.
+- URL-encode every value interpolated into the request path or query string before issuing the command.
+- Accept these user-facing filters and map them to the API params:
+  - `--slice-by` -> `sliceBy`
+  - `--impact` -> `impacts`
+  - `--type` -> `issueTypes`
+  - `--rule` -> `ruleKeys`
+  - `--severity` -> `severities`
+  - `--status` -> `statuses`
+- Validate every user-supplied filter before building the request. If any value fails validation, stop and tell the user what was rejected and why - do not run the command.
+- Validation rules:
+  - `--slice-by` must be one of `RULE_KEY`, `SEVERITY`, `SOFTWARE_QUALITY`, `STATUS`, `TYPE`
+  - `--impact` must be a comma-separated list of values matching `^[A-Z_]+$`
+  - `--type` must be a comma-separated subset of `BUG`, `CODE_SMELL`, `SECURITY_HOTSPOT`, `VULNERABILITY`
+  - `--rule` must be a comma-separated list of values matching `^[a-zA-Z0-9_\\-:]+$`
+  - `--severity` must be a comma-separated subset of `BLOCKER`, `HIGH`, `INFO`, `LOW`, `MEDIUM`
+  - `--status` must be a comma-separated subset of `ACCEPTED`, `CLOSED`, `CONFIRMED`, `FALSE_POSITIVE`, `FIXED`, `OPEN`, `RESOLVED`, `REVIEWED`, `TO_REVIEW`
+
+### Step 4: Run the issue-count-history endpoint
+
+```bash
+sonar api GET "/organizations/issue-count-history?entityId=<ENTITY_ID>&entityType=<PROJECT_BRANCH|PORTFOLIO>&startDate=<YYYY-MM-DD>T00:00:00Z[&endDate=<YYYY-MM-DD>T00:00:00Z][&sliceBy=<FIELD>][&impacts=<VALUE[,VALUE...]>][&issueTypes=<VALUE[,VALUE...]>][&ruleKeys=<VALUE[,VALUE...]>][&severities=<VALUE[,VALUE...]>][&statuses=<VALUE[,VALUE...]>]"
+```
+
+Rules:
+
+- Required params: `entityId`, `entityType`, `startDate`
+- Optional params: `endDate`, `sliceBy`, `impacts`, `issueTypes`, `ruleKeys`, `severities`, `statuses`
+- Use `entityType=PROJECT_BRANCH` with the resolved `branchId` for project or branch history.
+- Use `entityType=PORTFOLIO` with the verified portfolio UUID for portfolio history.
+- Omit `sliceBy` for one aggregate line.
+- Do not pass `sliceBy=NONE`.
+- Counts carry forward on days with no new analysis.
+- Resolution is daily UTC.
+- History can still have gaps when analysis is sparse.
+
+Hints:
+
+- For long time periods or heavily segmented requests, the result can be large and should be cached or saved.
+
+### Step 5: Format the result
+
+- For trend questions, render every returned series and state the UTC date range used.
+- State whether the history scope is a project branch or a portfolio.
+- If the user did not specify how to format the result, default to a table with one row per date and one column per returned series.
+- Use one aggregate series when `sliceBy` is omitted.
+- Use one series per returned segment when `sliceBy` is present.
+- If the user explicitly asked to graph or visualize the history, a chart is acceptable, but do not make charts the default.
+- If filters narrow the data to one segment while `sliceBy` is still present, present the segmented result returned by the endpoint rather than collapsing it manually.
+- If analysis is sparse or missing on some days, say that explicitly rather than smoothing over gaps.

--- a/skills/sonar-list-projects/SKILL.md
+++ b/skills/sonar-list-projects/SKILL.md
@@ -41,13 +41,21 @@ If a `--query` search term was provided, validate it matches `^[a-zA-Z0-9_\-\. ]
 
 ### Step 3: Run `sonar list projects`
 
-Build and run the command using a shell command:
+Build and run the command using a shell command. Use `--page-size 500` and continue paging until the full result set is retrieved.
 
 ```bash
-sonar list projects [--query <search-term>]
+sonar list projects --page-size 500 --page <page-number> [--query <search-term>]
 ```
 
 Only include `--query` if a search term was provided.
+
+Pagination rules:
+
+- Start with `--page 1`.
+- Keep incrementing `--page` until the full result set has been retrieved.
+- If the CLI exposes a total count, use it to decide when paging is complete.
+- If the CLI does not expose a total count, stop when a page returns fewer than `--page-size` results.
+- For requests that ask for "all projects" or for any downstream ranking/discovery workflow, do not stop after the first page.
 
 ### Step 4: Format the results
 
@@ -73,7 +81,7 @@ Found **8 project(s)**:
 No projects found. If you expected results, check your authentication with `sonar auth status`.
 ```
 
-**If the result is paginated** (500 projects returned), note: *"Showing first 500 projects. Use a search term to narrow results."*
+If results required multiple pages, note that the output was assembled from the full paginated result set.
 
 ### Step 5: Next steps
 

--- a/skills/sonar-measures-history/SKILL.md
+++ b/skills/sonar-measures-history/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: sonar-measures-history
+description: Fetch SonarQube project, branch, or portfolio metric trend history via sonarqube-cli across organizations history endpoints
+argument-hint: "(project <project-key>|<project-name> [--branch name]) | (portfolio <portfolio-id>|<portfolio-name>) [--metric key[,key...]] [--start yyyy-mm-dd] [--end yyyy-mm-dd]"
+allowed-tools: Read, Grep, Bash(sonar:*)
+---
+
+# SonarQube — Measures History
+
+Use this skill for project, branch, or portfolio metric trend history when the answer should come from Sonar measures-history endpoints.
+
+This skill covers:
+
+- metric history over time
+- project key/name and branch ID resolution for history queries
+- portfolio name and UUID resolution for history queries
+- time-series formatting guidance
+
+## Usage
+
+```
+sonar-measures-history my-project --metric coverage --start 2026-04-28
+sonar-measures-history "My Project Name" --metric coverage --start 2026-04-28
+sonar-measures-history my-project --metric reliability_rating --start 2026-04-28 --end 2026-05-28
+sonar-measures-history my-project --metric coverage,duplicated_lines_density --branch release/2.0 --start 2026-04-28
+sonar-measures-history --portfolio-id 123e4567-e89b-12d3-a456-426614174000 --metric coverage,reliability_rating --start 2026-04-28
+sonar-measures-history --portfolio-name "Code Orchestration" --metric coverage --start 2026-04-28
+sonar-measures-history my-project --metric bugs --branch release/2.0 --start 2026-04-28
+```
+
+Representative user requests this skill should handle:
+
+- "Graph coverage for main over 90 days."
+- "Graph portfolio coverage over the last quarter."
+- "Show coverage and duplicated_lines_density over the last month."
+- "How has security_rating changed this quarter?"
+
+## Command selection
+
+Use the command that matches the current stage of the workflow:
+
+- Project name input: resolve the exact project key with `sonar list projects --query <PROJECT_NAME>`.
+- Project key input: resolve the branch entry with `sonar api GET "/api/project_branches/list?project=<PROJECT_KEY>"` and use its `branchId` as `entityId`.
+- Portfolio name input: resolve enterprise and portfolio IDs with `sonar api GET` against the enterprise endpoints.
+- History fetch: use `sonar api GET "/organizations/measures-history?..."`
+
+Do not stay in "raw API mode" for every step just because the final history call uses `sonar api GET`.
+Project-name resolution should use `sonar list projects` first, then switch to `sonar api GET` only for branch/entity resolution and history retrieval.
+
+## Prerequisites
+
+This skill uses the `sonarqube-cli` command. The CLI must be installed and authenticated before proceeding.
+
+This skill also uses endpoints that are exclusive to SonarQube Cloud for the time being.
+The CLI must be authenticated with a valid SonarQube Cloud instance:
+- `sonarcloud.io`
+- `sonarqube.us`
+
+**Before proceeding**, verify that `sonar` is available on your PATH and authenticated.
+
+If a Sonar command fails because of sandbox, keychain, or local-state problems, retry the same Sonar command with elevated execution before concluding that authentication is broken.
+
+If the elevated retry succeeds, treat `sonar` as requiring elevated execution for the rest of the current task. Run subsequent `sonar` commands elevated instead of retrying each one in the sandbox first.
+
+Operational notes:
+
+- In sandboxed applications `sonar` may print valid JSON and still exit nonzero because of local-state or keychain problems. Inspect stdout before discarding a result when the payload looks complete.
+- Keychain-backed auth may require elevated execution outside the normal sandbox.
+- Typical signals include `Failed to access the system keychain`, credential-manager access failures, and `EPERM` writing under `~/.sonar`.
+- When requesting elevated execution for Sonar API reads, prefer a reusable approval prefix such as `["sonar","api","GET"]` to avoid repeated approval churn.
+
+If `sonar` still is not available or authenticated after the retry, do not attempt to call any alternative commands or invent alternatives, and show the user:
+
+> Unable to fetch Sonar history data.
+>
+> **Possible causes:**
+> - `sonarqube-cli` not installed or not authenticated — invoke the sonar-integrate skill
+
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then re-check and continue; if they decline, stop.
+
+## Instructions
+
+### Step 1: Resolve the target entity and entity ID
+
+- Require exactly one target scope:
+  - a project key or project name, optionally with `--branch`, for `PROJECT_BRANCH`
+  - or a verified `--portfolio-id` UUID for `PORTFOLIO`
+  - or a `--portfolio-name` that must be resolved to a verified portfolio UUID before continuing
+- If both a project selector and any portfolio selector (`--portfolio-id` or `--portfolio-name`) are supplied, stop and ask the user to choose one scope.
+- If both `--portfolio-id` and `--portfolio-name` are supplied, prefer the verified `--portfolio-id` and use the name only as a consistency check when helpful.
+- Use only verified project keys and portfolio UUIDs from the user or Sonar output.
+
+#### Project scope (`PROJECT_BRANCH`)
+
+- If the user provided a project key directly, validate it against `^[a-zA-Z0-9_\\-\\.:]+$`.
+- If the user provided a project name instead of a key, resolve the exact project key before calling `project_branches/list`.
+- Do not use `sonar api GET "/api/components/search_projects?...` to resolve a project name for this skill.
+- Use `sonar list projects --query <PROJECT_NAME>` for project-name lookup, because that is the intended search flow and has clearer name/key filtering semantics.
+- To resolve a project name, use the same lookup flow as `sonar-list-projects`:
+
+```bash
+sonar list projects --page-size 500 --page <PAGE_NUMBER> --query <PROJECT_NAME>
+```
+
+- Continue paging until the full matching result set has been checked.
+- If the project-name lookup returns multiple plausible projects, ask the user to choose instead of guessing.
+- If the project-name lookup returns no matches, stop and tell the user no project was found rather than falling through to the branch lookup.
+- For `PROJECT_BRANCH`, resolve the project branch entry with:
+
+```bash
+sonar api GET "/api/project_branches/list?project=<PROJECT_KEY>"
+```
+
+- For `PROJECT_BRANCH`, use the branch with `isMain: true` when the user did not specify a branch.
+- For `PROJECT_BRANCH`, use the `branchId` field from the selected branch entry as the `entityId` for `/organizations/measures-history`.
+- Do not use `branchUuidV1`; this skill should use `branchId`.
+- For `PROJECT_BRANCH`, if the user specified a branch, pick the matching branch entry and use its `branchId`.
+
+#### Portfolio scope (`PORTFOLIO`)
+
+- If the user provided only a portfolio name, resolve the enterprise UUID first if needed:
+
+```bash
+sonar api GET "/enterprises/enterprises"
+```
+
+- URL-encode every value interpolated into the request path or query string before issuing the command.
+  - Example: `Code Orchestration` -> `Code%20Orchestration`
+
+- Then look up the portfolio by name:
+
+```bash
+sonar api GET "/enterprises/portfolios?enterpriseId=<ENTERPRISE_UUID>&q=<PORTFOLIO_NAME>"
+```
+
+- Use only a verified portfolio UUID returned by Sonar output.
+- If the lookup returns multiple plausible portfolios, ask the user to choose instead of guessing.
+- Use `entityType=PORTFOLIO` and `entityId=<PORTFOLIO_UUID>` directly after resolution.
+
+### Step 2: Resolve and validate the time range
+
+- Convert relative windows to concrete UTC dates before building commands.
+- Use inclusive UTC calendar semantics for relative windows:
+  - `"last N days"` and `"past N days"` mean exactly `N` daily UTC points ending on the current UTC date.
+  - Compute `startDate = today_utc - (N - 1) days` and `endDate = today_utc`.
+  - `"this month"` means the first day of the current UTC month through the current UTC date.
+  - `"last month"` means the first day of the previous UTC month through the last day of the previous UTC month.
+  - `"this quarter"` means the first day of the current UTC quarter through the current UTC date.
+  - `"last quarter"` means the first day of the previous UTC quarter through the last day of the previous UTC quarter.
+- Worked examples assuming today is `2026-05-29` UTC:
+  - `"last 30 days"` -> `startDate=2026-04-30`, `endDate=2026-05-29`
+  - `"this quarter"` -> `startDate=2026-04-01`, `endDate=2026-05-29`
+  - `"last quarter"` -> `startDate=2026-01-01`, `endDate=2026-03-31`
+- Validate `--start` and `--end` as `YYYY-MM-DD`.
+- `startDate` more than one year in the past is rejected by the organizations history endpoints.
+- If `--end` is omitted, let the endpoint use its default latest bound.
+
+### Step 3: Validate metric requests
+
+- Accept one or more verified Sonar metric keys.
+- When the user supplies multiple metrics, pass them as a comma-separated list in `metricKeys`.
+- Preserve the user-requested metric order unless there is a formatting reason to group series differently in the response.
+- Common verified examples for this skill:
+  - `coverage`
+  - `bugs`
+  - `vulnerabilities`
+  - `code_smells`
+  - `duplicated_lines_density`
+  - `ncloc`
+  - `sqale_rating`
+  - `reliability_rating`
+  - `security_rating`
+  - `security_hotspots`
+
+### Step 4: Run the measures-history endpoint
+
+```bash
+sonar api GET "/organizations/measures-history?entityId=<ENTITY_ID>&entityType=<PROJECT_BRANCH|PORTFOLIO>&metricKeys=<VERIFIED_METRIC_KEY[,VERIFIED_METRIC_KEY...]>&startDate=<YYYY-MM-DD>T00:00:00Z[&endDate=<YYYY-MM-DD>T00:00:00Z]"
+```
+
+Rules:
+
+- Required params: `entityId`, `entityType`, `metricKeys`, `startDate`
+- Optional params: `endDate`
+- Use `entityType=PROJECT_BRANCH` with the resolved `branchId` for project or branch history.
+- Use `entityType=PORTFOLIO` with the verified portfolio UUID for portfolio history.
+- `metricKeys` accepts a comma-separated list of one or more metric keys.
+- `value` is always a string.
+- Parse values using the metric type.
+- History can have gaps when analysis is sparse.
+
+Hints:
+
+- For long time periods or large metric key sets the result can be large, and should be cached or saved
+
+### Step 5: Format the result
+
+- For trend questions, render every requested metric series and state the UTC date range used.
+- State whether the history scope is a project branch or a portfolio.
+- If the user did not specify how to format the result, default to a table with one row per date and one column per requested metric.
+- If analysis is sparse or missing on some days, say that explicitly rather than smoothing over gaps.

--- a/skills/sonar-measures/SKILL.md
+++ b/skills/sonar-measures/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: sonar-measures
+description: Disambiguate Sonar analytics requests and route them to the correct measure-related skill
+argument-hint: "\"<analytics question or request>\""
+allowed-tools: Read, Grep
+---
+
+# SonarQube — Measures
+
+Use this skill only when the task is about Sonar analytics data but the correct downstream analytics skill is not yet obvious.
+
+Do not use this skill when the request already clearly matches a concrete skill.
+Do not use this skill for generic metric-catalog or rule-metadata requests that should be answered directly by MCP tools.
+
+This router does not write Sonar API commands or perform shared normalization. It only decides which downstream skill should own the request.
+
+This skill covers:
+
+- ambiguous analytics-discovery prompts
+- mixed prompts that may fit more than one measure-related skill
+- routing guidance for downstream Sonar analytics skills when one of the supported history or portfolio-aggregate skills is the correct owner
+
+## Usage
+
+```
+sonar-measures "Summarize the current measures for the Finance portfolio."
+sonar-measures "Show quality trends for this project."
+sonar-measures "Show severity trends for the Finance portfolio."
+sonar-measures "Compare issue-count trend and coverage trend."
+```
+
+Representative user requests this skill should handle:
+
+- "Summarize the current measures for this portfolio."
+- "Show quality trends for this service."
+- "Show severity trends for the Finance portfolio."
+- "Compare issue-count trend and coverage trend."
+
+## Instructions
+
+### Step 1: Decide whether the router is needed
+
+- If the request already clearly matches a concrete skill, do not use this router. Invoke the downstream skill directly.
+- If the request is only asking which Sonar metrics exist in general, do not use this router. Use the direct metric-discovery MCP tool instead.
+- If the request asks for portfolio membership, per-project rankings, top-N projects inside a portfolio, or other portfolio drilldown beyond current aggregate measures, do not route it to `sonar-portfolio-measures`; that skill only covers `/enterprises/portfolio-measures`.
+- Use this router only when the request is vague, mixed, or discovery-oriented and you need to choose the correct downstream skill first.
+
+Direct examples that should bypass this router:
+
+- "Graph coverage for main over 90 days." -> `sonar-measures-history`
+- "Graph portfolio coverage over the last quarter." -> `sonar-measures-history`
+- "Show me issue count over the last month." -> `sonar-issue-count-history`
+- "What is the quality gate ratio for this portfolio?" -> `sonar-portfolio-measures`
+- "Which projects currently have unresolved vulnerabilities?" -> `sonar-list-issues`
+
+### Step 2: Route ambiguous requests to one owner
+
+Choose exactly one downstream skill before any execution work begins.
+
+| Request shape | Route to |
+| ------------- | -------- |
+| Time-series numeric metrics over a project, branch, or portfolio | `sonar-measures-history` |
+| Time-series issue counts or issue trends by type, severity, status, impact, or rule | `sonar-issue-count-history` |
+| Current portfolio aggregate measures from `/enterprises/portfolio-measures` | `sonar-portfolio-measures` |
+| Current issue inspection, unresolved vulnerabilities, or issue searches by severity, type, status, or rule | `sonar-list-issues` |
+
+Tie-breakers:
+
+- If the request asks for trends over time, prefer one of the history skills.
+- If the request asks for current portfolio aggregate state such as quality-gate ratio, releasability rating, or project-branch counts, prefer `sonar-portfolio-measures`.
+- If the request mixes current issue discovery with time-series counts, ask the user which one they want first instead of guessing.
+- If the request is discovery-oriented but clearly about issue-count segmentation over time, default to `sonar-issue-count-history`.
+- If the request is discovery-oriented but clearly about current portfolio aggregate measures, default to `sonar-portfolio-measures`.
+- If the request is discovery-oriented but clearly trend-focused, default to `sonar-measures-history`.
+
+Examples:
+
+- "Summarize the current measures for the Finance portfolio." -> `sonar-portfolio-measures`
+- "Show quality trends for this service." -> `sonar-measures-history`
+- "Show severity trends for the Finance portfolio." -> `sonar-issue-count-history`
+- "Compare issue-count trend and coverage trend." -> ask one clarifying question before routing
+
+### Step 3: Delegate immediately
+
+Once the target skill is chosen, invoke that downstream skill end-to-end.
+
+Do not duplicate auth handling, date-window interpretation, metric validation, paging rules, or endpoint instructions in this router. The downstream skill owns those details.
+
+## Next steps
+
+- For project-branch or portfolio metric trend history: *"Invoke the sonar-measures-history skill."*
+- For project-branch or portfolio issue count trend history: *"Invoke the sonar-issue-count-history skill."*
+- For current portfolio aggregate measures: *"Invoke the sonar-portfolio-measures skill."*
+- For current issue searches: *"Invoke the sonar-list-issues skill."*

--- a/skills/sonar-portfolio-measures/SKILL.md
+++ b/skills/sonar-portfolio-measures/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: sonar-portfolio-measures
+description: Fetch SonarQube enterprise portfolio aggregate measures via sonarqube-cli
+argument-hint: "[--portfolio-id uuid|--portfolio-name name] [--metric key[,key...]]"
+allowed-tools: Read, Grep, Bash(sonar:*)
+---
+
+# SonarQube — Portfolio Measures
+
+Use this skill for enterprise portfolio aggregate analytics when the answer should come from `/enterprises/portfolio-measures`.
+
+This skill covers:
+
+- portfolio aggregate metrics
+- portfolio name and UUID resolution
+- response-body filtering for requested aggregate metrics
+
+## Usage
+
+```
+sonar-portfolio-measures --portfolio-id 123e4567-e89b-12d3-a456-426614174000 --metric quality-gate-ratio
+sonar-portfolio-measures --portfolio-name "Finance" --metric quality-gate-ratio
+sonar-portfolio-measures --portfolio-id 123e4567-e89b-12d3-a456-426614174000 --metric releasability_rating,project_branch_count
+sonar-portfolio-measures --portfolio-name "Finance"
+```
+
+Representative user requests this skill should handle:
+
+- "What is the quality gate ratio for this portfolio?"
+- "Show releasability_rating for this portfolio."
+- "Show matched_project_branch_count and project_branch_count for Finance."
+- "Summarize the current portfolio measures."
+
+## Command selection
+
+Use the command that matches the current stage of the workflow:
+
+- Portfolio aggregates: use `sonar api GET "/enterprises/portfolio-measures?..."`, then filter the response body to the requested aggregate metrics.
+
+Resolve the portfolio identifier first, then call the portfolio-measures endpoint once and filter the returned payload locally when the user requested specific aggregate metrics.
+
+## Prerequisites
+
+This skill uses the `sonarqube-cli` command. The CLI must be installed and authenticated before proceeding.
+
+This skill also uses endpoints that are exclusive to SonarQube Cloud for the time being.
+The CLI must be authenticated with a valid SonarQube Cloud instance:
+- `sonarcloud.io`
+- `sonarqube.us`
+
+**Before proceeding**, verify that `sonar` is available on your PATH and authenticated.
+
+If a Sonar command fails because of sandbox, keychain, or local-state problems, retry the same Sonar command with elevated execution before concluding that authentication is broken.
+
+If the elevated retry succeeds, treat `sonar` as requiring elevated execution for the rest of the current task. Run subsequent `sonar` commands elevated instead of retrying each one in the sandbox first.
+
+Operational notes:
+
+- In sandboxed applications `sonar` may print valid JSON and still exit nonzero because of local-state or keychain problems. Inspect stdout before discarding a result when the payload looks complete.
+- Keychain-backed auth may require elevated execution outside the normal sandbox.
+- Typical signals include `Failed to access the system keychain`, credential-manager access failures, and `EPERM` writing under `~/.sonar`.
+- When requesting elevated execution for Sonar API reads, prefer a reusable approval prefix such as `["sonar","api","GET"]` to avoid repeated approval churn.
+
+If `sonar` still is not available or authenticated after the retry, do not attempt to call any alternative commands or invent alternatives, and show the user:
+
+> Unable to fetch Sonar portfolio analytics data.
+>
+> **Possible causes:**
+> - `sonarqube-cli` not installed or not authenticated — invoke the sonar-integrate skill
+
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then re-check and continue; if they decline, stop.
+
+## Instructions
+
+### Step 1: Resolve the portfolio identifier
+
+- Require exactly one portfolio selector:
+  - a verified `--portfolio-id` UUID
+  - or a `--portfolio-name` that must be resolved to a verified portfolio UUID before continuing
+- If both `--portfolio-id` and `--portfolio-name` are supplied, prefer the verified `--portfolio-id` and use the name only as a consistency check when helpful.
+- Use only verified enterprise and portfolio UUIDs from the user or Sonar output.
+- If the user provided only a portfolio name, resolve it to a verified portfolio UUID using the environment's existing enterprise portfolio lookup flow before continuing.
+- If the lookup returns multiple plausible portfolios, ask the user to choose instead of guessing.
+- If the lookup returns no matches, stop and tell the user no portfolio was found rather than falling back to a guessed UUID.
+- Use the verified `portfolioId` directly after resolution.
+
+### Step 2: Choose the portfolio flow
+
+Use `/enterprises/portfolio-measures` when the user asks for aggregate portfolio metrics:
+
+```bash
+sonar api GET "/enterprises/portfolio-measures?portfolioId=<PORTFOLIO_UUID>"
+```
+
+Rules:
+
+- The endpoint accepts `portfolioId` only.
+- Do not append `metric`, `metricKey`, or any other metric filter to this request.
+- If the user requested one or more aggregate metrics, fetch the full payload once and then filter the response body locally to those requested metrics.
+- If the user did not request a specific aggregate metric, summarize the relevant aggregate fields returned by the payload.
+
+Key fields to inspect in the response body:
+
+- `releasability_rating`
+- `releasability_status_distribution`
+- `matched_project_branch_count`
+- `project_branch_count`
+
+Supported aggregate filtering in this skill:
+
+- `quality-gate-ratio` -> derive from `releasability_status_distribution`
+- `releasability_rating` -> return the raw field
+- `releasability_status_distribution` -> return the raw field
+- `matched_project_branch_count` -> return the raw field
+- `project_branch_count` -> return the raw field
+
+If the user requests multiple aggregate metrics, return only those requested fields and derived values from the fetched payload.
+If the user requests an aggregate metric that is not represented in this payload, say that this endpoint does not expose it instead of inventing a mapping.
+
+Quality gate ratio recipe:
+
+1. Read `releasability_status_distribution`.
+2. Treat `OK` as passed and `ERROR` as failed.
+3. Compute `OK / (OK + ERROR)`.
+4. Also report `releasability_rating`.
+
+### Step 3: Format the result
+
+- For portfolio aggregates, report only the requested filtered metrics when the user named specific ones, and include the raw source fields used for any derived value.
+- When no aggregate metric filter was requested, summarize the main fields returned by `/enterprises/portfolio-measures`.


### PR DESCRIPTION
This PR adds a number of skills to the agent-plugin for performing analytics work on the O&R squad's metrics and historic data endpoints. These are the first step in providing [Agentic Insights](https://sonarsource.atlassian.net/browse/MMF-5571) and currently designed around using the Sonar CLI's `api` option.

The `sonar-measures` skill is a router to differentiate between the similar endpoint utilization skills which was found to improve GPT-5.4 and Sonnet's recognition of the skill when not being directly invoked. The other skills are directly invoking the sonar APIs to be able to invoke the desired endpoint.