### PR TITLE
Workaround for Codex custom marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -4,8 +4,9 @@
         {
             "name": "sonarqube",
             "source": {
-                "source": "local",
-                "path": "./"
+                "source": "url",
+                "url": "https://github.com/SonarSource/sonarqube-agent-plugins.git",
+                "ref": "master"
             },
             "policy": {
                 "installation": "AVAILABLE",


### PR DESCRIPTION
Fixes Codex plugin installation, which was failing with plugin "sonarqube" was not found in marketplace "sonar" because the marketplace entry used a local source with path: "./", and Codex's resolver rejects any local path that resolves to the repository root (openai/codex#17066).

This change switches the entry to a url source pointing at the repository's Git URL, which Codex supports for plugins that live at the repo root.

I verified locally with codex 0.139.0 that the plugin now lists, installs, and lands a complete plugin tree in the cache (manifest, skills, and mcp.json all present). This approach was chosen over a symlink wrapper subdirectory because Codex silently drops symlinks when copying local plugin sources into its cache (openai/codex#18863), which would leave the installed plugin empty on all platforms, Windows included.

Note that the url source installs the plugin from the ref pinned in marketplace.json (currently master), so this fix takes effect for users only once it lands on that branch.