### PR TITLE
Revert to local Codex marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -4,9 +4,8 @@
         {
             "name": "sonarqube",
             "source": {
-                "source": "url",
-                "url": "https://github.com/SonarSource/sonarqube-agent-plugins.git",
-                "ref": "master"
+                "source": "local",
+                "path": "./"
             },
             "policy": {
                 "installation": "AVAILABLE",


### PR DESCRIPTION
Once Codex CLI v0.142.0 is out, run `codex plugin marketplace add SonarSource/sonarqube-agent-plugins --ref d9d978bb0d7adbbc58ddc0ca92a1292b1844e607` ,
check that the marketplace is added via `codex plugin marketplace list`, launch Codex and check for `/plugins`. SonarQube plugin should be searchable and when you click it should show the available capabilities - 9 skills and an MCP.

If this works, the PR can be merged