### PR TITLE
Warn about container runtime requirement and invalid CLI alternatives

### DIFF
--- a/skills/sonar-analyze/SKILL.md
+++ b/skills/sonar-analyze/SKILL.md
@@ -20,7 +20,7 @@ sonar-analyze src/auth/login.py      # analyze a specific file
 
 This skill requires the SonarQube MCP Server to be configured and at least one of the tools `mcp__sonarqube__run_advanced_code_analysis`, `mcp__sonarqube__analyze_code_snippet`, or `mcp__sonarqube__analyze_file_list` to be available in your session.
 
-**Before proceeding**, verify at least one of these tools is accessible. If none are, do not attempt to call any CLI commands or invent alternatives, and show the user:
+**Before proceeding**, verify at least one of these tools is accessible. If none are, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` does not exist), and show the user:
 
 > Unable to reach the SonarQube MCP Server.
 >

--- a/skills/sonar-analyze/SKILL.md
+++ b/skills/sonar-analyze/SKILL.md
@@ -28,8 +28,9 @@ This skill requires the SonarQube MCP Server to be configured and at least one o
 > - MCP server not registered — invoke the sonar-integrate skill to configure the SonarQube MCP Server, then restart the agent session
 > - Credentials not configured — invoke the sonar-integrate skill
 > - Project key missing or invalid — pass an explicit key if needed, verify `sonar-project.properties`, or re-run the sonar-integrate skill for this project
+> - No container runtime available — the MCP server needs Docker, Podman, or Nerdctl running to start
 
-Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to restart the agent session so the new MCP tools become available; if they decline, stop.
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running and to restart the agent session so the new MCP tools become available; if they decline, stop.
 
 ## Instructions
 

--- a/skills/sonar-coverage/SKILL.md
+++ b/skills/sonar-coverage/SKILL.md
@@ -22,7 +22,7 @@ sonar-coverage my-project --file src/auth/login.py  # line-by-line detail for on
 
 This skill requires the SonarQube MCP Server to be configured and the tools `mcp__sonarqube__search_files_by_coverage` and `mcp__sonarqube__get_file_coverage_details` to be available in your session.
 
-**Before proceeding**, verify the tools are accessible. If they are not, do not attempt to call any CLI commands or invent alternatives, and show the user:
+**Before proceeding**, verify the tools are accessible. If they are not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar coverage` do not exist), and show the user:
 
 > Unable to reach the SonarQube MCP Server, or project key not found.
 >
@@ -30,8 +30,9 @@ This skill requires the SonarQube MCP Server to be configured and the tools `mcp
 > - MCP server not registered — invoke the sonar-integrate skill to configure the SonarQube MCP Server, then restart the agent session
 > - Credentials not configured — invoke the sonar-integrate skill
 > - Project key is wrong or no default project in MCP config — pass an explicit key, or verify `sonar-project.properties` / re-run the sonar-integrate skill for this project
+> - No container runtime available — the MCP server needs Docker, Podman, or Nerdctl running to start
 
-Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to restart the agent session so the new MCP tools become available; if they decline, stop.
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running and to restart the agent session so the new MCP tools become available; if they decline, stop.
 
 ## Instructions
 

--- a/skills/sonar-dependency-risks/SKILL.md
+++ b/skills/sonar-dependency-risks/SKILL.md
@@ -22,7 +22,7 @@ sonar-dependency-risks my-project --pr 42
 
 This skill requires SonarQube Advanced Security (available on SonarQube Cloud Enterprise plan, or SonarQube Server 2025.4 Enterprise edition or higher), the SonarQube MCP Server to be configured, and the tool `mcp__sonarqube__search_dependency_risks` to be available in your session.
 
-**Before proceeding**, verify the tool is accessible. If it is not, do not attempt to call any CLI commands or invent alternatives, and show the user:
+**Before proceeding**, verify the tool is accessible. If it is not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar dependency-risks` do not exist), and show the user:
 
 > Unable to fetch dependency risks.
 >
@@ -31,8 +31,9 @@ This skill requires SonarQube Advanced Security (available on SonarQube Cloud En
 > - MCP server not registered — invoke the sonar-integrate skill to configure the SonarQube MCP Server, then restart the agent session
 > - Credentials not configured — invoke the sonar-integrate skill
 > - Project key is wrong or no default project in MCP config — pass an explicit key, or verify `sonar-project.properties` / re-run the sonar-integrate skill for this project
+> - No container runtime available — the MCP server needs Docker, Podman, or Nerdctl running to start
 
-Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to restart the agent session so the new MCP tools become available; if they decline, stop.
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running and to restart the agent session so the new MCP tools become available; if they decline, stop.
 
 ## Instructions
 

--- a/skills/sonar-duplication/SKILL.md
+++ b/skills/sonar-duplication/SKILL.md
@@ -23,7 +23,7 @@ sonar-duplication my-project --file src/auth/login.py   # duplication detail for
 
 This skill requires the SonarQube MCP Server to be configured and the tools `mcp__sonarqube__search_duplicated_files` and `mcp__sonarqube__get_duplications` to be available in your session.
 
-**Before proceeding**, verify the tools are accessible. If they are not, do not attempt to call any CLI commands or invent alternatives, and show the user:
+**Before proceeding**, verify the tools are accessible. If they are not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar duplication` do not exist), and show the user:
 
 > Unable to reach the SonarQube MCP Server, or project key not found.
 >
@@ -31,8 +31,9 @@ This skill requires the SonarQube MCP Server to be configured and the tools `mcp
 > - MCP server not registered — invoke the sonar-integrate skill to configure the SonarQube MCP Server, then restart the agent session
 > - Credentials not configured — invoke the sonar-integrate skill
 > - Project key is wrong or no default project in MCP config — pass an explicit key, or verify `sonar-project.properties` / re-run the sonar-integrate skill for this project
+> - No container runtime available — the MCP server needs Docker, Podman, or Nerdctl running to start
 
-Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to restart the agent session so the new MCP tools become available; if they decline, stop.
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running and to restart the agent session so the new MCP tools become available; if they decline, stop.
 
 ## Instructions
 

--- a/skills/sonar-integrate/SKILL.md
+++ b/skills/sonar-integrate/SKILL.md
@@ -175,7 +175,7 @@ Then run the appropriate command yourself using a shell command, adding **`--non
 
 If the project key is not already known from `sonar-project.properties` or prior context, add **`--project <key>`** to the project-only command.
 
-After integrate completes, tell the user to enable the MCP server manually in Cursor: open **Settings → MCP**, find the `sonarqube` entry, and toggle it on. A Cursor session restart may be needed for the tools to appear.
+After integrate completes, tell the user to enable the MCP server manually in Cursor: open **Settings → MCP**, find the `sonarqube` entry, and toggle it on. Also tell the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running. A Cursor session restart may be needed for the tools to appear.
 
 #### 4.e — Antigravity (`sonar integrate antigravity`)
 
@@ -197,7 +197,7 @@ Then run the appropriate command yourself using a shell command, adding **`--non
 
 If the project key is not already known from `sonar-project.properties` or prior context, add **`--project <key>`** to the project-only command.
 
-Tell the user to restart the Antigravity session if MCP tools do not appear after integrate completes.
+Tell the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running, and to restart the Antigravity session if MCP tools do not appear after integrate completes.
 
 #### 4.f — Gemini CLI *(legacy)*
 
@@ -218,7 +218,7 @@ After all steps complete, print a summary:
 
   sonarqube-cli:     updated via sonar self-update
   Authentication:    token stored in system keychain
-  MCP Server:        configured (restart the agent session if tools do not appear)
+  MCP Server:        configured (ensure a container runtime (Docker, Podman, or Nerdctl) is running, then restart the agent session if tools do not appear)
 
 You can verify at any time with:  sonar auth status
 To refresh CLI + wiring later:    invoke the sonar-integrate skill again
@@ -246,7 +246,7 @@ If path **4.d** (Cursor) was taken, add these lines to the summary:
 
 ```
   CLI integrate:     wired via sonar integrate cursor
-  MCP Server:        enable manually in Cursor Settings → MCP (restart may be needed)
+  MCP Server:        enable manually in Cursor Settings → MCP (ensure a container runtime (Docker, Podman, or Nerdctl) is running; restart may be needed)
 ```
 
 And **omit** the default `MCP Server` line (it is replaced by the Cursor-specific one above).

--- a/skills/sonar-quality-gate/SKILL.md
+++ b/skills/sonar-quality-gate/SKILL.md
@@ -22,7 +22,7 @@ sonar-quality-gate my-project --pr 42
 
 This skill requires the SonarQube MCP Server to be configured and the tool `mcp__sonarqube__get_project_quality_gate_status` to be available in your session.
 
-**Before proceeding**, verify the tool is accessible. If it is not, do not attempt to call any CLI commands or invent alternatives, and show the user:
+**Before proceeding**, verify the tool is accessible. If it is not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar quality-gate` do not exist), and show the user:
 
 > Unable to reach the SonarQube MCP Server, or project key not found.
 >
@@ -30,8 +30,9 @@ This skill requires the SonarQube MCP Server to be configured and the tool `mcp_
 > - MCP server not registered — invoke the sonar-integrate skill to configure the SonarQube MCP Server, then restart the agent session
 > - Credentials not configured — invoke the sonar-integrate skill
 > - Project key is wrong or no default project in MCP config — pass an explicit key, or verify `sonar-project.properties` / re-run the sonar-integrate skill for this project
+> - No container runtime available — the MCP server needs Docker, Podman, or Nerdctl running to start
 
-Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to restart the agent session so the new MCP tools become available; if they decline, stop.
+Then ask the user (yes/no) whether to run the sonar-integrate skill now. If they confirm, invoke the sonar-integrate skill yourself and follow it end-to-end in this session, then ask the user to ensure a container runtime (Docker, Podman, or Nerdctl) is running and to restart the agent session so the new MCP tools become available; if they decline, stop.
 
 ## Instructions
 


### PR DESCRIPTION
Before, the only way for an Antigravity user to learn about the container runtime requirement for the MCP server was by running the `/mcp` command to see the following error:

<img width="765" height="94" alt="image" src="https://github.com/user-attachments/assets/4fbddd93-0e82-4586-b49e-d88ba9f77d21" />

I edited the skill files to note the container runtime as a possible cause of failure, and adjusted the "Next Steps" instructions after the `sonar-integrate` skill invocation to mention a container runtime needs to be started before restarting the agent session.

<img width="1594" height="250" alt="image" src="https://github.com/user-attachments/assets/ad0b5826-8bc1-4a87-989d-6a8af7696e08" />
<img width="2422" height="122" alt="image" src="https://github.com/user-attachments/assets/59fba60d-18db-4344-a621-f8774c36d704" />
