### PR TITLE
Dex 82 83 84 agent plugins updates

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -47,7 +47,7 @@ Invoke it when another skill surfaces a failure that points to one of the condit
 - "Check this code for quality problems"
 - "Generate a method that does X and analyze it for issues"
 
-**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Agentic Analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
+**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex agentic analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
 
 ### Coverage
 **Example user requests:**

--- a/README.md
+++ b/README.md
@@ -62,21 +62,23 @@ There is **no** `@vendor` marketplace install (for example `sonarqube@sonar` is 
 
 ## Repository layout
 
-| Agent                     | Location                                                     |
-|---------------------------|--------------------------------------------------------------|
-| **Claude Code**           | `.claude-plugin/`, `skills/`, `claude-hooks/`, `scripts/`    |
-| **Cursor**                | `.cursor-plugin/` (+ shared `mcp.json`)                      |
-| **GitHub Copilot CLI**    | `.github/plugin/` (+ shared `mcp.json`)                      |
-| **Codex**                 | `.codex-plugin/`                                             |
-| **Antigravity**           | `plugin.json`, `mcp_config.json`, `rules/`, shared `skills/` |
-| **Gemini CLI** *(legacy)* | `gemini-extension.json`, `GEMINI.md`                         |
-| **Kiro**                  | `kiro-power/`                                                |
+| Agent                     | Location                                                             |
+|---------------------------|-----------------------------------------------------------------------|
+| **Claude Code**           | `.claude-plugin/`, `skills/`, `agents/`, `claude-hooks/`, `scripts/` |
+| **Cursor**                | `.cursor-plugin/` (+ shared `mcp.json`, `agents/`)                   |
+| **GitHub Copilot CLI**    | `.github/plugin/` (+ shared `mcp.json`, `agents/`)                   |
+| **Codex**                 | `.codex-plugin/`                                                     |
+| **Antigravity**           | `plugin.json`, `mcp_config.json`, `rules/`, shared `skills/`         |
+| **Gemini CLI** *(legacy)* | `gemini-extension.json`, `GEMINI.md`                                 |
+| **Kiro**                  | `kiro-power/`                                                        |
 
 ---
 
 ## Usage
 
 Skills are the same across agents. Ask in natural language, invoke skills explicitly, or use the **SonarQube MCP** tools your client shows after MCP starts.
+
+On **Claude Code**, **GitHub Copilot CLI**, and **Cursor**, the plugin also ships a **`sonarqube-reviewer`** agent (`agents/sonarqube-reviewer.agent.md`) that composes the skills below into a single PR/diff review — quality gate, issues, dependency risks, duplication, and coverage — without editing code itself.
 
 MCP reference: [SonarQube MCP Server docs](https://docs.sonarsource.com/sonarqube-mcp-server/).
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ SonarQube combines deterministic checks with AI-assisted workflows so quality ru
 
 ## What do the plugins include
 
-The Plugin helps agents connect to [SonarQube CLI](https://cli.sonarqube.com/) and [SonarQube MCP Server](https://docs.sonarsource.com/sonarqube-mcp-server) for issue detection, checking project metrics such as test coverage and duplications, fetch dependency risks, etc. Claude Code, Copilot CLI, Codex, and Antigravity (through SonarQube CLI) install agent hooks for secrets scanning and, when entitled, Agentic Analysis.
+The Plugin helps agents connect to [SonarQube CLI](https://cli.sonarqube.com/) and [SonarQube MCP Server](https://docs.sonarsource.com/sonarqube-mcp-server) for issue detection, checking project metrics such as test coverage and duplications, fetch dependency risks, etc. Claude Code, Copilot CLI, Codex, and Antigravity (through SonarQube CLI) install agent hooks for secrets scanning and, when entitled, Vortex agentic analysis.
 
-How to use: Run `/sonarqube:sonar-integrate` after installation to walk through setup — CLI installation, authentication, and wiring up the MCP Server and hooks. From there, use slash commands like `/sonarqube:sonar-quality-gate` to check quality gates or interact naturally with prompts like "analyze my code for issues," "show open SonarQube findings," or "check my coverage." With Agentic Analysis enabled, verification happens automatically after each edit with no manual invocation required.
+How to use: Run `/sonarqube:sonar-integrate` after installation to walk through setup — CLI installation, authentication, and wiring up the MCP Server and hooks. From there, use slash commands like `/sonarqube:sonar-quality-gate` to check quality gates or interact naturally with prompts like "analyze my code for issues," "show open SonarQube findings," or "check my coverage." With Vortex agentic analysis enabled, verification happens automatically after each edit with no manual invocation required.
 
 ## Prerequisites
 
-- A SonarQube account (**SonarQube Cloud**, **Server**, or **Community Build**). Some features (for example Agentic Analysis) depend on your SonarQube Cloud organization settings.
+- A SonarQube account (**SonarQube Cloud**, **Server**, or **Community Build**). Some features (for example Vortex agentic analysis) depend on your SonarQube Cloud organization settings.
 - **[SonarQube CLI](https://cli.sonarqube.com/)** (`sonar`) on your machine.
 - A **container runtime** (Docker, Podman, or Nerdctl) for the MCP server image.
 
@@ -37,7 +37,7 @@ sonar auth status
 ```bash
 sonar integrate claude        # Claude Code: MCP, hooks, secrets scanning, etc.
 sonar integrate copilot       # GitHub Copilot CLI: MCP, hooks, secrets scanning, etc.
-sonar integrate codex         # Codex: MCP, hooks, secrets scanning, Agentic Analysis hook
+sonar integrate codex         # Codex: MCP, hooks, secrets scanning, Vortex agentic analysis hook
 sonar integrate antigravity   # Antigravity: hooks, instructions, CAG, MCP patch (after plugin install)
 ```
 
@@ -54,7 +54,7 @@ Antigravity uses **two independent install surfaces**. For full parity with Clau
 | Step                 | Command                              | What it installs                                                              |
 |----------------------|--------------------------------------|-------------------------------------------------------------------------------|
 | **1. Plugin bundle** | `agy plugin install <git-url\|path>` | Skills, agent rules (`rules/sonarqube.md`), MCP (`mcp_config.json`)           |
-| **2. CLI integrate** | `sonar integrate antigravity`        | Secrets hooks, Agentic Analysis instructions, Context Augmentation, MCP patch |
+| **2. CLI integrate** | `sonar integrate antigravity`        | Secrets hooks, Vortex agentic analysis instructions, Context Augmentation, MCP patch |
 
 There is **no** `@vendor` marketplace install (for example `sonarqube@sonar` is not supported). Use a Git URL, archive, or local path.
 
@@ -198,7 +198,7 @@ agy plugin install https://github.com/SonarSource/sonarqube-agent-plugins
 # 2. Auth + hooks / instructions / CAG / MCP patch
 sonar auth login
 sonar integrate antigravity              # project-scoped (default)
-# sonar integrate antigravity -g         # global (all projects; Agentic Analysis skipped)
+# sonar integrate antigravity -g         # global (all projects; Vortex agentic analysis skipped)
 ```
 
 Or use **`/sonarqube:sonar-integrate`** inside Antigravity for a guided flow. Restart the agent session if MCP tools do not appear.
@@ -258,7 +258,7 @@ Plugin bundle: **`.codex-plugin/`** — catalog **`sonar`**, plugin **`sonarqube
 
 3. Start a Codex session and install **sonarqube** from that catalog using the `/plugins` command
 
-4. From your project directory, run **`sonar integrate codex`** (add **`--project <key>`** if needed). This wires MCP in **`.codex/config.toml`**, secrets hooks, and—when your SonarQube Cloud org has Agentic Analysis—a **PostToolUse** hook on **`apply_patch`** that runs analysis on the git change set after each edit.
+4. From your project directory, run **`sonar integrate codex`** (add **`--project <key>`** if needed). This wires MCP in **`.codex/config.toml`**, secrets hooks, and—when your SonarQube Cloud org has Vortex agentic analysis—a **PostToolUse** hook on **`apply_patch`** that runs analysis on the git change set after each edit.
 
 Same workflows as **[Usage](#usage)** once MCP is connected.
 

--- a/agents/sonarqube-reviewer.agent.md
+++ b/agents/sonarqube-reviewer.agent.md
@@ -1,0 +1,56 @@
+---
+name: sonarqube-reviewer
+description: Reviews code changes against SonarQube quality, security, and dependency-risk standards by composing this plugin's sonar-* skills. Use proactively before merging a PR or when the user asks for a SonarQube-based code review, a second opinion on code quality, or to "review my changes with SonarQube."
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git status:*), Bash(git branch:*), Bash(git symbolic-ref:*), Bash(sonar:*), mcp__sonarqube__*, Skill
+---
+
+# SonarQube Reviewer
+
+You review code changes against SonarQube quality, security, coverage, duplication, and dependency-risk standards. You are a **reviewer, not a fixer** — you never edit code yourself. You compose this plugin's existing `sonar-*` skills rather than calling MCP tools or `sonar` CLI commands directly; those skills already encode the correct tool calls, parameter resolution, and CLI fallbacks.
+
+## Step 1: Scope the review
+
+Determine what to review, in this order:
+
+- If the user gave a PR number, review that PR.
+- Otherwise, diff against the default branch: detect it with `git symbolic-ref refs/remotes/origin/HEAD` (falls back to `main`, then `master`, if that fails), then run `git diff --name-only <base>...HEAD`. Only ask the user for the base branch if none of those resolve.
+- If the user named a specific file or path, scope to that instead.
+
+If none of the above yields a clear scope, ask: *"What should I review — a PR number, the current branch's diff, or a specific file?"*
+
+## Step 2: Resolve the project key
+
+Resolve a project key from the user's arguments or `sonar-project.properties` if you can. Pass whatever you have (or nothing) to each skill below — they resolve it themselves and only ask you for one if they truly need it and can't (e.g. sonar-list-issues, or any skill's CLI fallback).
+
+## Step 3: Quality gate headline
+
+Invoke the **sonar-quality-gate** skill with the resolved project key and branch/PR context. This gives the overall pass/fail verdict and every failing condition.
+
+## Step 4: Issues on the change set
+
+If reviewing a PR or branch, prefer invoking the **sonar-list-issues** skill once, scoped to that branch/PR (`--branch`/`--pr`) — this already returns SonarQube's own analysis of the changed lines in one call. Only fall back to the per-file loop below when there's no branch/PR to scope to, or that call returns nothing for files you expect to have findings.
+
+Otherwise, invoke the **sonar-analyze** skill once per changed file, capped at 15 files — if there are more, analyze the 15 largest changed files and tell the user how many were skipped rather than silently dropping them.
+
+## Step 5: Dependency risk check
+
+If any changed file is a dependency manifest, invoke the **sonar-dependency-risks** skill and have it run `sonar analyze dependency-risks` for a fresh scan — the change may introduce risks not yet reflected in prior server-side results.
+
+## Step 6: Duplication and coverage (when relevant)
+
+- If a changed or added file is substantially rewritten, invoke the **sonar-duplication** skill for it.
+- If logic changed without a matching test change, invoke the **sonar-coverage** skill.
+
+Skip both for trivial diffs (e.g. a config or version bump) — don't run every skill unconditionally.
+
+## Step 7: Synthesize a single report
+
+Combine the results of the steps above into one report, not a sequence of separate skill outputs:
+
+1. **Headline verdict** — merge-ready or changes requested, tied directly to the quality gate status from Step 3.
+2. **Issues** — grouped by severity, scoped to the changed files first, with project-wide issues (if fetched) called out separately.
+3. **Dependency risks** — if any were found in Step 5.
+4. **Duplication / coverage notes** — if checked in Step 6.
+5. **Next step** — *"Invoke the sonar-fix-issue skill with `<rule> <file>:<line>` to fix a specific issue, or ask me to fix them all."* Never make the edit yourself in this review.
+
+If a skill's underlying MCP tool and CLI fallback both failed (per that skill's own error message), say so explicitly in the relevant section of the report instead of silently omitting it.

--- a/rules/sonarqube.md
+++ b/rules/sonarqube.md
@@ -10,7 +10,7 @@ The `sonar-integrate` skill is a preliminary initialization and recovery skill f
 
 - installs `sonarqube-cli` if missing and updates it to the latest version,
 - authenticates the CLI via `sonar auth login` (token stored in system keychain),
-- runs `sonar integrate antigravity` to wire secrets scanning hooks, Agentic Analysis instructions, Context Augmentation, and MCP configuration.
+- runs `sonar integrate antigravity` to wire secrets scanning hooks, Vortex agentic analysis instructions, Context Augmentation, and MCP configuration.
 
 Migrating from the SonarQube Gemini extension? Run `agy plugin import gemini`, then `sonar integrate antigravity`.
 
@@ -50,7 +50,7 @@ Invoke the `sonar-integrate` skill when another skill surfaces a failure that po
 - "Check this code for quality problems"
 - "Generate a method that does X and analyze it for issues"
 
-**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Agentic Analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
+**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex agentic analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
 
 ### Coverage
 **Example user requests:**

--- a/skills/sonar-analyze/SKILL.md
+++ b/skills/sonar-analyze/SKILL.md
@@ -76,9 +76,9 @@ Do not accept a directory as input. If the user provides one, ask them to specif
 
 After running the sonar-integrate skill, the SonarQube MCP Server often has a **default project** for this workspace, so **`projectKey` is sometimes unnecessary** — pass it only when the tool schema requires it or the user targets another project.
 
-Two tools may be available depending on whether the connected organization is eligible for Agentic Analysis:
+Two tools may be available depending on whether the connected organization is eligible for Vortex agentic analysis:
 
-**Try `mcp__sonarqube__run_advanced_code_analysis` first** (available when the organization is eligible for Agentic Analysis).
+**Try `mcp__sonarqube__run_advanced_code_analysis` first** (available when the organization is eligible for Vortex agentic analysis).
 
 Before calling it, detect the current branch name using `git branch --show-current`. If git is unavailable, use `main` as a fallback.
 
@@ -98,7 +98,7 @@ Then call with:
 - `language` — detected language key
 - `scope` — `"TEST"` or `"MAIN"`
 
-**If none of the three MCP tools are available, fall back to the CLI:**
+**If none of the three MCP tools are available, fall back to the CLI's Vortex agentic analysis:**
 
 ```bash
 sonar analyze agentic --file <file-path> [--file <other-file-path> ...] --format json [--branch <branch-name>] [-p <project-key>]
@@ -106,7 +106,7 @@ sonar analyze agentic --file <file-path> [--file <other-file-path> ...] --format
 
 Same backend as `run_advanced_code_analysis` (repeatable `--file` covers multi-file too), and the practical fallback for `analyze_code_snippet`/`analyze_file_list` as well — they have no direct CLI equivalent, but this achieves the same goal.
 
-Requires an Agentic Analysis-eligible organization. If the org isn't eligible, or `sonar` isn't installed/authenticated, show the standard message from Prerequisites — don't guess further commands.
+Requires a Vortex agentic analysis-eligible organization. If the org isn't eligible, or `sonar` isn't installed/authenticated, show the standard message from Prerequisites — don't guess further commands.
 
 ### Step 4: Format the results
 

--- a/skills/sonar-analyze/SKILL.md
+++ b/skills/sonar-analyze/SKILL.md
@@ -2,7 +2,7 @@
 name: sonar-analyze
 description: Analyze a file or code snippet for quality and security issues using SonarQube
 argument-hint: "[file-path]"
-allowed-tools: Read, Glob, Bash(git branch:*), Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*)
+allowed-tools: Read, Glob, Bash(git branch:*), Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*), Bash(sonar:*)
 ---
 
 # SonarQube — Code Analysis
@@ -20,9 +20,9 @@ sonar-analyze src/auth/login.py      # analyze a specific file
 
 This skill requires the SonarQube MCP Server to be configured and at least one of the tools `mcp__sonarqube__run_advanced_code_analysis`, `mcp__sonarqube__analyze_code_snippet`, or `mcp__sonarqube__analyze_file_list` to be available in your session.
 
-**Before proceeding**, verify at least one of these tools is accessible. If none are, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` does not exist).
+**Before proceeding**, verify at least one of these tools is accessible. If none are, try the CLI fallback in Step 3 before giving up — don't invent other CLI commands (e.g. `sonar mcp call` does not exist).
 
-**First, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
+**If the CLI fallback also fails or doesn't apply, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
 
 - **Not enabled / not registered** → recommend running the sonar-integrate skill.
 - **Enabled but its tools are still unavailable** → configuration is correct but the server failed to start. The most common cause is that the container runtime is not running — the MCP server launches inside Docker/Podman/Nerdctl via `sonar run mcp`, so a correctly configured server still produces no tools if the daemon is stopped. Run `docker ps` yourself (falling back to `podman ps` / `nerdctl ps`) to confirm which cause applies: if it errors, the runtime is down; after the user starts it, confirm the same command succeeds before asking them to restart the agent session.
@@ -97,6 +97,16 @@ Then call with:
 - `codeSnippet` — full file content (optional; provide to narrow analysis to a specific snippet)
 - `language` — detected language key
 - `scope` — `"TEST"` or `"MAIN"`
+
+**If none of the three MCP tools are available, fall back to the CLI:**
+
+```bash
+sonar analyze agentic --file <file-path> [--file <other-file-path> ...] --format json [--branch <branch-name>] [-p <project-key>]
+```
+
+Same backend as `run_advanced_code_analysis` (repeatable `--file` covers multi-file too), and the practical fallback for `analyze_code_snippet`/`analyze_file_list` as well — they have no direct CLI equivalent, but this achieves the same goal.
+
+Requires an Agentic Analysis-eligible organization. If the org isn't eligible, or `sonar` isn't installed/authenticated, show the standard message from Prerequisites — don't guess further commands.
 
 ### Step 4: Format the results
 

--- a/skills/sonar-coverage/SKILL.md
+++ b/skills/sonar-coverage/SKILL.md
@@ -2,7 +2,7 @@
 name: sonar-coverage
 description: Find files with low test coverage and inspect uncovered lines in a SonarQube project (project key optional when MCP integration already defines the default project)
 argument-hint: "[project-key?] [--max n] [--file key] [--pr id]"
-allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*)
+allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*), Bash(sonar:*)
 ---
 
 # SonarQube — Coverage
@@ -22,9 +22,9 @@ sonar-coverage my-project --file src/auth/login.py  # line-by-line detail for on
 
 This skill requires the SonarQube MCP Server to be configured and the tools `mcp__sonarqube__search_files_by_coverage` and `mcp__sonarqube__get_file_coverage_details` to be available in your session.
 
-**Before proceeding**, verify the tools are accessible. If they are not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar coverage` do not exist).
+**Before proceeding**, verify the tools are accessible. If they are not, try the `sonar api` CLI fallback in Step 3 before giving up — don't invent other CLI commands (e.g. `sonar mcp call` or `sonar coverage` do not exist).
 
-**First, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
+**If the CLI fallback also fails (for example `sonar` not installed/authenticated, or no project key can be resolved), narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
 
 - **Not enabled / not registered** → recommend running the sonar-integrate skill.
 - **Enabled but its tools are still unavailable** → configuration is correct but the server failed to start. The most common cause is that the container runtime is not running — the MCP server launches inside Docker/Podman/Nerdctl via `sonar run mcp`, so a correctly configured server still produces no tools if the daemon is stopped. Run `docker ps` yourself (falling back to `podman ps` / `nerdctl ps`) to confirm which cause applies: if it errors, the runtime is down; after the user starts it, confirm the same command succeeds before asking them to restart the agent session.
@@ -95,6 +95,14 @@ If no files are returned (all files exceed the threshold), say: *"All files meet
 Then offer to drill in:
 *"Ask me to inspect any of these files for uncovered lines, or invoke the sonar-coverage skill with `--file <file-key>` (add a project key only if needed)."*
 
+**If `mcp__sonarqube__search_files_by_coverage` is unavailable, fall back to `sonar api`.** This needs an explicit project key (no MCP default) — if none was resolved in Step 1, ask the user or invoke sonar-list-projects, then stop.
+
+```bash
+sonar api get "/api/measures/component_tree?component=<project-key>&metricKeys=coverage,line_coverage,branch_coverage&qualifiers=FIL&strategy=leaves&s=metric&metricSort=coverage&asc=true[&pullRequest=<id>]"
+```
+
+Use `metricKeys`. If a call 400s unexpectedly, add `-v` to see the actual server error. Read `coverage` from each component's `measures` array and present it in the same table format above.
+
 #### Flow B — Line detail (`--file <key>` given, or user asks to inspect a file)
 
 Call `mcp__sonarqube__get_file_coverage_details`:
@@ -127,6 +135,16 @@ Lines with no test coverage: 14, 15, 23, 45–52, 67
 ```
 
 If the file is fully covered, say: *"All lines in this file are covered."*
+
+**If `mcp__sonarqube__get_file_coverage_details` is unavailable, fall back to `sonar api`:**
+
+```bash
+sonar api get "/api/sources/lines?key=<file-key>[&pullRequest=<id>]"
+```
+
+Each returned line has coverage fields (covered/uncovered, branch hit counts) — derive the uncovered-lines list and partially-covered-branches table from those.
+
+If this also fails, show the standard message above — don't guess further commands.
 
 ### Step 4: Next steps
 

--- a/skills/sonar-dependency-risks/SKILL.md
+++ b/skills/sonar-dependency-risks/SKILL.md
@@ -2,7 +2,7 @@
 name: sonar-dependency-risks
 description: Search for software composition analysis (SCA) dependency risks in a SonarQube project (project key optional when MCP integration already defines the default project)
 argument-hint: "[project-key?] [--branch name] [--pr id]"
-allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*)
+allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*), Bash(sonar:*)
 ---
 
 # SonarQube — Dependency Risks
@@ -22,9 +22,9 @@ sonar-dependency-risks my-project --pr 42
 
 This skill requires SonarQube Advanced Security (available on SonarQube Cloud Enterprise plan, or SonarQube Server 2025.4 Enterprise edition or higher), the SonarQube MCP Server to be configured, and the tool `mcp__sonarqube__search_dependency_risks` to be available in your session.
 
-**Before proceeding**, verify the tool is accessible. If it is not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar dependency-risks` do not exist).
+**Before proceeding**, verify the tool is accessible. If it is not, try the CLI fallback in Step 3 before giving up — don't invent other CLI commands (e.g. `sonar mcp call` or `sonar dependency-risks` do not exist).
 
-**First, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration. (This only explains missing tools, not the Advanced Security entitlement — see the first cause below.)
+**If the CLI fallback also fails or doesn't apply, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration. (This only explains missing tools, not the Advanced Security entitlement — see the first cause below.)
 
 - **Not enabled / not registered** → recommend running the sonar-integrate skill.
 - **Enabled but its tools are still unavailable** → configuration is correct but the server failed to start. The most common cause is that the container runtime is not running — the MCP server launches inside Docker/Podman/Nerdctl via `sonar run mcp`, so a correctly configured server still produces no tools if the daemon is stopped. Run `docker ps` yourself (falling back to `podman ps` / `nerdctl ps`) to confirm which cause applies: if it errors, the runtime is down; after the user starts it, confirm the same command succeeds before asking them to restart the agent session.
@@ -72,6 +72,24 @@ Include **`projectKey` only if** you resolved one in Step 1 **and** the tool req
 ```
 
 Omit `projectKey` from the payload when the integration default applies. Omit unused optional fields.
+
+**If `mcp__sonarqube__search_dependency_risks` is unavailable, fall back to the CLI.** This needs an explicit project key — if none was resolved in Step 1, ask the user or invoke sonar-list-projects, then stop.
+
+Run `sonar auth status` to check the connected server. On a self-hosted **SonarQube Server**:
+
+```bash
+sonar api get "/api/v2/sca/issues-releases?projectKey=<project-key>[&branchKey=<name>][&pullRequestKey=<id>]"
+```
+
+On **SonarQube Cloud**, `sonar api` can't reach this endpoint yet (lives on a separate subdomain; may change in a future CLI release) — run a fresh scan instead:
+
+```bash
+sonar analyze dependency-risks -p <project-key> --format table
+```
+
+This re-scans manifests rather than querying prior results, so it may surface issues not yet on the server dashboard — expected, not an error. Map its output into the same table as Step 4.
+
+If this also fails, show the standard message above — don't guess further commands.
 
 ### Step 4: Format the results
 

--- a/skills/sonar-duplication/SKILL.md
+++ b/skills/sonar-duplication/SKILL.md
@@ -2,7 +2,7 @@
 name: sonar-duplication
 description: Find files with code duplications in a SonarQube project and inspect duplication blocks for a file (project key optional when MCP integration already defines the default project)
 argument-hint: "[project-key?] [--pr id] [--page-size n] [--page n] [--file key]"
-allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*)
+allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*), Bash(sonar:*)
 ---
 
 # SonarQube — Duplication
@@ -23,9 +23,9 @@ sonar-duplication my-project --file src/auth/login.py   # duplication detail for
 
 This skill requires the SonarQube MCP Server to be configured and the tools `mcp__sonarqube__search_duplicated_files` and `mcp__sonarqube__get_duplications` to be available in your session.
 
-**Before proceeding**, verify the tools are accessible. If they are not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar duplication` do not exist).
+**Before proceeding**, verify the tools are accessible. If they are not, try the `sonar api` CLI fallback in Step 3 before giving up — don't invent other CLI commands (e.g. `sonar mcp call` or `sonar duplication` do not exist).
 
-**First, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
+**If the CLI fallback also fails (for example `sonar` not installed/authenticated, or no project key can be resolved), narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
 
 - **Not enabled / not registered** → recommend running the sonar-integrate skill.
 - **Enabled but its tools are still unavailable** → configuration is correct but the server failed to start. The most common cause is that the container runtime is not running — the MCP server launches inside Docker/Podman/Nerdctl via `sonar run mcp`, so a correctly configured server still produces no tools if the daemon is stopped. Run `docker ps` yourself (falling back to `podman ps` / `nerdctl ps`) to confirm which cause applies: if it errors, the runtime is down; after the user starts it, confirm the same command succeeds before asking them to restart the agent session.
@@ -112,6 +112,14 @@ Then offer to drill in:
 
 *"Ask me to open duplications for any file, or invoke the sonar-duplication skill with `--file <file-key>` (add a project key only if needed)."*
 
+**If `mcp__sonarqube__search_duplicated_files` is unavailable, fall back to `sonar api`.** This needs an explicit project key (no MCP default) — if none was resolved in Step 1, ask the user or invoke sonar-list-projects, then stop.
+
+```bash
+sonar api get "/api/measures/component_tree?component=<project-key>&metricKeys=duplicated_lines,duplicated_blocks,duplicated_lines_density&qualifiers=FIL&strategy=leaves[&pullRequest=<id>]"
+```
+
+Use `metricKeys`; add `-v` if a call 400s unexpectedly. Manual pagination maps to `&p=<page>&ps=<page-size>`; there's no auto-fetch-all mode, so page yourself up to the 10,000-file cap if needed. Filter out components with all-zero duplication metrics, then present the same table as above.
+
 #### Flow B — Duplication detail (`--file <key>` given, or user asks to inspect a file)
 
 Call `mcp__sonarqube__get_duplications`:
@@ -138,6 +146,16 @@ Present duplication **blocks** from the response: for each block, show ranges, s
 ```
 
 If the file has no duplications in the response, say: *"No duplications were reported for this file."*
+
+**If `mcp__sonarqube__get_duplications` is unavailable, fall back to `sonar api`:**
+
+```bash
+sonar api get "/api/duplications/show?key=<file-key>[&pullRequest=<id>]"
+```
+
+Omit `pullRequest` when `--pr` was not given. The same **Browse** permission requirement applies. Present the returned blocks in the same format as above.
+
+If this also fails, show the standard message above — don't guess further commands.
 
 ### Step 4: Next steps
 

--- a/skills/sonar-fix-issue/SKILL.md
+++ b/skills/sonar-fix-issue/SKILL.md
@@ -2,7 +2,7 @@
 name: sonar-fix-issue
 description: Fix a specific SonarQube issue in code by rule key and location
 argument-hint: "[rule-key] [file-path:line]"
-allowed-tools: Read, Edit
+allowed-tools: Read, Edit, Bash(sonar:*)
 ---
 
 # SonarQube — Fix Issue
@@ -33,7 +33,7 @@ If neither a rule key nor a file path can be determined, ask: *"Which rule and f
 Call `mcp__sonarqube__show_rule` with the rule key to retrieve the full rule description,
 rationale, and remediation guidance before touching any code. **Do not add extra parameters** (such as `projectKey`) unless the tool schema requires them — after integration, rule lookup usually needs only the rule key.
 
-If the MCP server is unavailable, rely on built-in knowledge of SonarQube rules.
+If the MCP tool is unavailable, fall back to `sonar api get "/api/rules/show?key=<rule-key>"`. If `sonar` is also unavailable or unauthenticated, rely on built-in knowledge of SonarQube rules.
 
 ### Step 3: Read the file
 

--- a/skills/sonar-integrate/SKILL.md
+++ b/skills/sonar-integrate/SKILL.md
@@ -106,7 +106,7 @@ Pick exactly one branch below based on which agent you are. Do not run the other
 
 Run **`sonar integrate claude`**, which configures the **SonarQube MCP Server**, **secrets-scanning hooks**, and any other supported integration the CLI applies.
 
-It wires **MCP** (for skills like sonar-quality-gate, sonar-analyze, sonar-coverage, sonar-duplication, sonar-dependency-risks) and **secrets-scanning hooks** into the user’s Claude Code config. When available, SonarQube Agentic Analysis hooks are also installed.
+It wires **MCP** (for skills like sonar-quality-gate, sonar-analyze, sonar-coverage, sonar-duplication, sonar-dependency-risks) and **secrets-scanning hooks** into the user’s Claude Code config. When available, SonarQube Vortex agentic analysis hooks are also installed.
 
 Ask the user using a single-choice selector with these options:
 
@@ -144,7 +144,7 @@ Then run the appropriate command yourself using a shell command, and adding `--n
 
 #### 4.c — Codex (`sonar integrate codex`)
 
-Run **`sonar integrate codex`**, which configures the **SonarQube MCP Server**, **secrets-scanning hooks**, and—when your SonarQube Cloud org has Agentic Analysis—a **PostToolUse** hook on **`apply_patch`** that surfaces findings inline after edits.
+Run **`sonar integrate codex`**, which configures the **SonarQube MCP Server**, **secrets-scanning hooks**, and—when your SonarQube Cloud org has Vortex agentic analysis—a **PostToolUse** hook on **`apply_patch`** that surfaces findings inline after edits.
 
 Ask the user using a single-choice selector with these options:
 
@@ -164,7 +164,7 @@ If the project key is not already known from `sonar-project.properties` or prior
 
 #### 4.d — Cursor (`sonar integrate cursor`)
 
-Run **`sonar integrate cursor`**, which configures **secrets-scanning hooks** (`beforeSubmitPrompt`, `beforeReadFile`, and `preToolUse`), **MCP**, **Context Augmentation** (when entitled), and **Agentic Analysis instructions** (when entitled, project scope only).
+Run **`sonar integrate cursor`**, which configures **secrets-scanning hooks** (`beforeSubmitPrompt`, `beforeReadFile`, and `preToolUse`), **MCP**, **Context Augmentation** (when entitled), and **Vortex agentic analysis instructions** (when entitled, project scope only).
 
 Ask the user using a single-choice selector with these options:
 
@@ -186,7 +186,7 @@ After integrate completes, tell the user to enable the MCP server manually in Cu
 
 #### 4.e — Antigravity (`sonar integrate antigravity`)
 
-Run **`sonar integrate antigravity`**, which configures **secrets-scanning hooks**, **prompt-secrets and Agentic Analysis instructions**, **Context Augmentation** (when entitled), and **MCP** in the Antigravity harness.
+Run **`sonar integrate antigravity`**, which configures **secrets-scanning hooks**, **prompt-secrets and Vortex agentic analysis instructions**, **Context Augmentation** (when entitled), and **MCP** in the Antigravity harness.
 
 Ask the user using a single-choice selector with these options:
 
@@ -212,7 +212,7 @@ Gemini CLI starts the SonarQube MCP Server via `sonar run mcp`, which handles co
 
 Confirm that integration is ready — the MCP server will start automatically when Gemini CLI reads **`gemini-extension.json`**.
 
-Recommend migrating to **Antigravity** (**4.e**): run **`agy plugin import gemini`**, then **`sonar integrate antigravity`**. Gemini CLI did not support SonarQube hooks or Agentic Analysis wiring.
+Recommend migrating to **Antigravity** (**4.e**): run **`agy plugin import gemini`**, then **`sonar integrate antigravity`**. Gemini CLI did not support SonarQube hooks or Vortex agentic analysis wiring.
 
 ---
 

--- a/skills/sonar-quality-gate/SKILL.md
+++ b/skills/sonar-quality-gate/SKILL.md
@@ -2,7 +2,7 @@
 name: sonar-quality-gate
 description: Show SonarQube quality gate status for a project — pass/fail and each condition (metric key, threshold, actual value). Project key optional when MCP integration already defines the default project.
 argument-hint: "[project-key?] [--branch name] [--pr id]"
-allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*)
+allowed-tools: Read, Grep, Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*), Bash(sonar:*)
 ---
 
 # SonarQube — Quality gate
@@ -22,9 +22,9 @@ sonar-quality-gate my-project --pr 42
 
 This skill requires the SonarQube MCP Server to be configured and the tool `mcp__sonarqube__get_project_quality_gate_status` to be available in your session.
 
-**Before proceeding**, verify the tool is accessible. If it is not, do not attempt to call any CLI commands or invent alternatives (e.g. `sonar mcp call` or `sonar quality-gate` do not exist).
+**Before proceeding**, verify the tool is accessible. If it is not, try the `sonar api` CLI fallback in Step 3 before giving up — don't invent other CLI commands (e.g. `sonar mcp call` or `sonar quality-gate` do not exist).
 
-**First, narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
+**If the CLI fallback also fails (for example `sonar` not installed/authenticated, or no project key can be resolved), narrow down the cause** — check whether the `sonarqube` MCP server is enabled in this agent's configuration.
 
 - **Not enabled / not registered** → recommend running the sonar-integrate skill.
 - **Enabled but its tools are still unavailable** → configuration is correct but the server failed to start. The most common cause is that the container runtime is not running — the MCP server launches inside Docker/Podman/Nerdctl via `sonar run mcp`, so a correctly configured server still produces no tools if the daemon is stopped. Run `docker ps` yourself (falling back to `podman ps` / `nerdctl ps`) to confirm which cause applies: if it errors, the runtime is down; after the user starts it, confirm the same command succeeds before asking them to restart the agent session.
@@ -149,6 +149,14 @@ The tool returns a top-level **`status`** (`OK`, `ERROR`, or other values your s
 }
 ```
 
+**If `mcp__sonarqube__get_project_quality_gate_status` is unavailable, fall back to `sonar api`.** This needs an explicit project key (no MCP default) — if none was resolved in Step 1, ask the user or invoke sonar-list-projects, then stop.
+
+```bash
+sonar api get "/api/qualitygates/project_status?projectKey=<project-key>[&branch=<name>][&pullRequest=<id>]"
+```
+
+Note the query params are `branch` and `pullRequest`. Response shape (`status` + `conditions`) is the same as above.
+
 ### Step 4: Format the results
 
 Present a concise report:
@@ -171,6 +179,14 @@ If the quality gate payload is missing or analysis has not run, say so clearly i
 ### Step 5: Deeper metrics (`get_component_measures`)
 
 To investigate **beyond** the gate (e.g. overall coverage, line coverage, bug counts, detailed ratings), call **`mcp__sonarqube__get_component_measures`** with the same branch/PR context if applicable, and pass `metricKeys` for the measures you need. Add **`projectKey` only when** the tool requires it and you have a resolved key; otherwise rely on the integration default (you can start from the `metricKey` values that failed or from the [SonarQube metric keys](https://docs.sonarsource.com/) documentation).
+
+**If the tool is unavailable, fall back to `sonar api`** (requires a resolved project key, same as Step 3's fallback):
+
+```bash
+sonar api get "/api/measures/component?component=<project-key>&metricKeys=<comma-separated-keys>[&branch=<name>][&pullRequest=<id>]"
+```
+
+If this also fails, show the standard message above — don't guess further commands.
 
 ### Step 6: Related skills
 


### PR DESCRIPTION
----
## Summary by Gitar

- **New Agent Persona:**
  - Added `sonarqube-reviewer` agent for PR and diff reviews using automated composition of existing skills.
- **Terminology Updates:**
  - Renamed "Agentic Analysis" to "Vortex agentic analysis" across all documentation, plugins, and skill definitions.
- **Skill Enhancements:**
  - Added CLI fallback support for `sonar-analyze` and `sonar-fix-issue` skills when MCP tools are unavailable.
  - Updated `sonar-fix-issue` to allow `Bash(sonar:*)` tool access.
- **Documentation & Configuration:**
  - Updated `README.md` and `rules/sonarqube.md` to reflect new agent capabilities and terminology.
  - Refreshed plugin descriptors (`plugin.json`, `marketplace.json`) to include the "Vortex" branding.

<sub>This will update automatically on new commits.</sub>