### PR TITLE
DEX-82 mention Vortex agentic analysis in startup script

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -9,9 +9,9 @@ const CLAUDE_INTEGRATION_ID = "claude-code";
 
 const HOOK_DISPLAY_NAMES = {
   "sonar-secrets": "Secrets Detection",
-  "sonar-sqaa": "Agentic Analysis",
+  "sonar-sqaa": "Vortex agentic analysis",
   "sonar-secrets-hooks": "Secrets Detection",
-  "sonar-sqaa-hook": "Agentic Analysis",
+  "sonar-sqaa-hook": "Vortex agentic analysis",
 };
 
 const DECLARATIVE_HOOK_FEATURE_IDS = new Set([


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation updates:**
  - Updated display names for `sonar-sqaa` and `sonar-sqaa-hook` to include 'Vortex agentic analysis' in `scripts/setup.js`.

<sub>This will update automatically on new commits.</sub>