### PR TITLE
DEX-98 rename Vortex agentic analysis to Vortex analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "sonarqube",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
       "source": "./"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
   "author": {
     "name": "Sonar",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
   "author": {
     "name": "Sonar",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -10,7 +10,7 @@
     "plugins": [
         {
             "name": "sonarqube",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
             "source": "./"
         }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
   "author": {
     "name": "Sonar",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "sonarqube",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
       "source": "./"
     }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
   "author": {
     "name": "Sonar",

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -47,7 +47,7 @@ Invoke it when another skill surfaces a failure that points to one of the condit
 - "Check this code for quality problems"
 - "Generate a method that does X and analyze it for issues"
 
-**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex agentic analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
+**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
 
 ### Coverage
 **Example user requests:**

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ SonarQube combines deterministic checks with AI-assisted workflows so quality ru
 
 ## What do the plugins include
 
-The Plugin helps agents connect to [SonarQube CLI](https://cli.sonarqube.com/) and [SonarQube MCP Server](https://docs.sonarsource.com/sonarqube-mcp-server) for issue detection, checking project metrics such as test coverage and duplications, fetch dependency risks, etc. Claude Code, Copilot CLI, Codex, and Antigravity (through SonarQube CLI) install agent hooks for secrets scanning and, when entitled, Vortex agentic analysis.
+The Plugin helps agents connect to [SonarQube CLI](https://cli.sonarqube.com/) and [SonarQube MCP Server](https://docs.sonarsource.com/sonarqube-mcp-server) for issue detection, checking project metrics such as test coverage and duplications, fetch dependency risks, etc. Claude Code, Copilot CLI, Codex, and Antigravity (through SonarQube CLI) install agent hooks for secrets scanning and, when entitled, Vortex analysis.
 
-How to use: Run `/sonarqube:sonar-integrate` after installation to walk through setup — CLI installation, authentication, and wiring up the MCP Server and hooks. From there, use slash commands like `/sonarqube:sonar-quality-gate` to check quality gates or interact naturally with prompts like "analyze my code for issues," "show open SonarQube findings," or "check my coverage." With Vortex agentic analysis enabled, verification happens automatically after each edit with no manual invocation required.
+How to use: Run `/sonarqube:sonar-integrate` after installation to walk through setup — CLI installation, authentication, and wiring up the MCP Server and hooks. From there, use slash commands like `/sonarqube:sonar-quality-gate` to check quality gates or interact naturally with prompts like "analyze my code for issues," "show open SonarQube findings," or "check my coverage." With Vortex analysis enabled, verification happens automatically after each edit with no manual invocation required.
 
 ## Prerequisites
 
-- A SonarQube account (**SonarQube Cloud**, **Server**, or **Community Build**). Some features (for example Vortex agentic analysis) depend on your SonarQube Cloud organization settings.
+- A SonarQube account (**SonarQube Cloud**, **Server**, or **Community Build**). Some features (for example Vortex analysis) depend on your SonarQube Cloud organization settings.
 - **[SonarQube CLI](https://cli.sonarqube.com/)** (`sonar`) on your machine.
 - A **container runtime** (Docker, Podman, or Nerdctl) for the MCP server image.
 
@@ -35,9 +35,9 @@ sonar auth status
 ```bash
 sonar integrate claude        # Claude Code: MCP, hooks, secrets scanning, etc.
 sonar integrate copilot       # GitHub Copilot CLI: MCP, hooks, secrets scanning, etc.
-sonar integrate codex         # Codex: MCP, hooks, secrets scanning, Vortex agentic analysis hook
+sonar integrate codex         # Codex: MCP, hooks, secrets scanning, Vortex analysis hook
 sonar integrate antigravity   # Antigravity: hooks, instructions, CAG, MCP patch (after plugin install)
-sonar integrate cursor        # Cursor: MCP, secret-scanning hooks, Vortex agentic analysis instructions
+sonar integrate cursor        # Cursor: MCP, secret-scanning hooks, Vortex analysis instructions
 ```
 
 Run these **after** `sonar auth login`. Use the **`/sonarqube:sonar-integrate`** skill if you prefer a guided flow (install/update CLI, login, then integrate).
@@ -114,7 +114,7 @@ agy plugin install https://github.com/SonarSource/sonarqube-agent-plugins
 # 2. Auth + hooks / instructions / CAG / MCP patch
 sonar auth login
 sonar integrate antigravity              # project-scoped (default)
-# sonar integrate antigravity -g         # global (all projects; Vortex agentic analysis skipped)
+# sonar integrate antigravity -g         # global (all projects; Vortex analysis skipped)
 ```
 
 Or use **`/sonarqube:sonar-integrate`** inside Antigravity for a guided flow. Restart the agent session if MCP tools do not appear.
@@ -169,7 +169,7 @@ Plugin bundle: **`.codex-plugin/`** — catalog **`sonar`**, plugin **`sonarqube
 
 3. Run **`sonar auth login`**.
 
-4. From your project directory, run **`sonar integrate codex`** (add **`--project <key>`** if needed). This wires MCP in **`.codex/config.toml`**, secrets hooks, and—when your SonarQube Cloud org has Vortex agentic analysis—a **PostToolUse** hook on **`apply_patch`** that runs analysis on the git change set after each edit.
+4. From your project directory, run **`sonar integrate codex`** (add **`--project <key>`** if needed). This wires MCP in **`.codex/config.toml`**, secrets hooks, and—when your SonarQube Cloud org has Vortex analysis—a **PostToolUse** hook on **`apply_patch`** that runs analysis on the git change set after each edit.
 
 Same workflows as **[Usage](#usage)** once MCP is connected.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "sonarqube",
   "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "mcpServers": {
     "sonarqube": {
       "command": "sonar",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "SonarQube is the AI code quality and security verification platform used by millions of developers to catch bugs, vulnerabilities, and leaked secrets. This plugin enforces those standards in the agent coding loop: 7,500+ distinct issue types, secrets scanning, agentic analysis, and quality gates across 40+ languages.",
   "author": {
     "name": "Sonar",

--- a/rules/sonarqube.md
+++ b/rules/sonarqube.md
@@ -10,7 +10,7 @@ The `sonar-integrate` skill is a preliminary initialization and recovery skill f
 
 - installs `sonarqube-cli` if missing and updates it to the latest version,
 - authenticates the CLI via `sonar auth login` (token stored in system keychain),
-- runs `sonar integrate antigravity` to wire secrets scanning hooks, Vortex agentic analysis instructions, Context Augmentation, and MCP configuration.
+- runs `sonar integrate antigravity` to wire secrets scanning hooks, Vortex analysis instructions, Context Augmentation, and MCP configuration.
 
 Migrating from the SonarQube Gemini extension? Run `agy plugin import gemini`, then `sonar integrate antigravity`.
 
@@ -50,7 +50,7 @@ Invoke the `sonar-integrate` skill when another skill surfaces a failure that po
 - "Check this code for quality problems"
 - "Generate a method that does X and analyze it for issues"
 
-**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex agentic analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
+**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
 
 ### Coverage
 **Example user requests:**

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -9,9 +9,9 @@ const CLAUDE_INTEGRATION_ID = "claude-code";
 
 const HOOK_DISPLAY_NAMES = {
   "sonar-secrets": "Secrets Detection",
-  "sonar-sqaa": "Vortex agentic analysis",
+  "sonar-sqaa": "Vortex analysis",
   "sonar-secrets-hooks": "Secrets Detection",
-  "sonar-sqaa-hook": "Vortex agentic analysis",
+  "sonar-sqaa-hook": "Vortex analysis",
 };
 
 const DECLARATIVE_HOOK_FEATURE_IDS = new Set([

--- a/skills/sonar-analyze/SKILL.md
+++ b/skills/sonar-analyze/SKILL.md
@@ -76,9 +76,9 @@ Do not accept a directory as input. If the user provides one, ask them to specif
 
 After running the sonar-integrate skill, the SonarQube MCP Server often has a **default project** for this workspace, so **`projectKey` is sometimes unnecessary** — pass it only when the tool schema requires it or the user targets another project.
 
-Two tools may be available depending on whether the connected organization is eligible for Vortex agentic analysis:
+Two tools may be available depending on whether the connected organization is eligible for Vortex analysis:
 
-**Try `mcp__sonarqube__run_advanced_code_analysis` first** (available when the organization is eligible for Vortex agentic analysis).
+**Try `mcp__sonarqube__run_advanced_code_analysis` first** (available when the organization is eligible for Vortex analysis).
 
 Before calling it, detect the current branch name using `git branch --show-current`. If git is unavailable, use `main` as a fallback.
 
@@ -98,7 +98,7 @@ Then call with:
 - `language` — detected language key
 - `scope` — `"TEST"` or `"MAIN"`
 
-**If none of the three MCP tools are available, fall back to the CLI's Vortex agentic analysis:**
+**If none of the three MCP tools are available, fall back to the CLI's Vortex analysis:**
 
 ```bash
 sonar analyze agentic --file <file-path> [--file <other-file-path> ...] --format json [--branch <branch-name>] [-p <project-key>]
@@ -106,7 +106,7 @@ sonar analyze agentic --file <file-path> [--file <other-file-path> ...] --format
 
 Same backend as `run_advanced_code_analysis` (repeatable `--file` covers multi-file too), and the practical fallback for `analyze_code_snippet`/`analyze_file_list` as well — they have no direct CLI equivalent, but this achieves the same goal.
 
-Requires a Vortex agentic analysis-eligible organization. If the org isn't eligible, or `sonar` isn't installed/authenticated, show the standard message from Prerequisites — don't guess further commands.
+Requires a Vortex analysis-eligible organization. If the org isn't eligible, or `sonar` isn't installed/authenticated, show the standard message from Prerequisites — don't guess further commands.
 
 ### Step 4: Format the results
 

--- a/skills/sonar-integrate/SKILL.md
+++ b/skills/sonar-integrate/SKILL.md
@@ -106,7 +106,7 @@ Pick exactly one branch below based on which agent you are. Do not run the other
 
 Run **`sonar integrate claude`**, which configures the **SonarQube MCP Server**, **secrets-scanning hooks**, and any other supported integration the CLI applies.
 
-It wires **MCP** (for skills like sonar-quality-gate, sonar-analyze, sonar-coverage, sonar-duplication, sonar-dependency-risks) and **secrets-scanning hooks** into the user’s Claude Code config. When available, SonarQube Vortex agentic analysis hooks are also installed.
+It wires **MCP** (for skills like sonar-quality-gate, sonar-analyze, sonar-coverage, sonar-duplication, sonar-dependency-risks) and **secrets-scanning hooks** into the user’s Claude Code config. When available, SonarQube Vortex analysis hooks are also installed.
 
 Ask the user using a single-choice selector with these options:
 
@@ -144,7 +144,7 @@ Then run the appropriate command yourself using a shell command, and adding `--n
 
 #### 4.c — Codex (`sonar integrate codex`)
 
-Run **`sonar integrate codex`**, which configures the **SonarQube MCP Server**, **secrets-scanning hooks**, and—when your SonarQube Cloud org has Vortex agentic analysis—a **PostToolUse** hook on **`apply_patch`** that surfaces findings inline after edits.
+Run **`sonar integrate codex`**, which configures the **SonarQube MCP Server**, **secrets-scanning hooks**, and—when your SonarQube Cloud org has Vortex analysis—a **PostToolUse** hook on **`apply_patch`** that surfaces findings inline after edits.
 
 Ask the user using a single-choice selector with these options:
 
@@ -164,7 +164,7 @@ If the project key is not already known from `sonar-project.properties` or prior
 
 #### 4.d — Cursor (`sonar integrate cursor`)
 
-Run **`sonar integrate cursor`**, which configures **secrets-scanning hooks** (`beforeSubmitPrompt`, `beforeReadFile`, and `preToolUse`), **MCP**, **Context Augmentation** (when entitled), and **Vortex agentic analysis instructions** (when entitled, project scope only).
+Run **`sonar integrate cursor`**, which configures **secrets-scanning hooks** (`beforeSubmitPrompt`, `beforeReadFile`, and `preToolUse`), **MCP**, **Context Augmentation** (when entitled), and **Vortex analysis instructions** (when entitled, project scope only).
 
 Ask the user using a single-choice selector with these options:
 
@@ -186,7 +186,7 @@ After integrate completes, tell the user to enable the MCP server manually in Cu
 
 #### 4.e — Antigravity (`sonar integrate antigravity`)
 
-Run **`sonar integrate antigravity`**, which configures **secrets-scanning hooks**, **prompt-secrets and Vortex agentic analysis instructions**, **Context Augmentation** (when entitled), and **MCP** in the Antigravity harness.
+Run **`sonar integrate antigravity`**, which configures **secrets-scanning hooks**, **prompt-secrets and Vortex analysis instructions**, **Context Augmentation** (when entitled), and **MCP** in the Antigravity harness.
 
 Ask the user using a single-choice selector with these options:
 
@@ -212,7 +212,7 @@ Gemini CLI starts the SonarQube MCP Server via `sonar run mcp`, which handles co
 
 Confirm that integration is ready — the MCP server will start automatically when Gemini CLI reads **`gemini-extension.json`**.
 
-Recommend migrating to **Antigravity** (**4.e**): run **`agy plugin import gemini`**, then **`sonar integrate antigravity`**. Gemini CLI did not support SonarQube hooks or Vortex agentic analysis wiring.
+Recommend migrating to **Antigravity** (**4.e**): run **`agy plugin import gemini`**, then **`sonar integrate antigravity`**. Gemini CLI did not support SonarQube hooks or Vortex analysis wiring.
 
 ---
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation & terminology:**
    - Renamed references from "Vortex agentic analysis" to "Vortex analysis" across documentation, README, rules, and setup scripts

<sub>This will update automatically on new commits.</sub>