### PR TITLE
MCP-573 Stop advertising `analyze_code_snippet` in the sonar-analyze

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,13 +41,13 @@ Invoke it when another skill surfaces a failure that points to one of the condit
 
 **What to do:** Invoke the `sonar-list-issues` skill end-to-end. It supports filtering by severity, type, status, rule, tag, component, branch, and pull request, and always passes `-p <project-key>` to the CLI.
 
-### Code Snippet Analysis
+### Code Analysis
 **Example user requests:**
-- "Analyze this code snippet for issues"
+- "Analyze this code for issues"
 - "Check this code for quality problems"
 - "Generate a method that does X and analyze it for issues"
 
-**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
+**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex analysis) and falls back to `mcp__sonarqube__analyze_file_list`, handling file reading and scope selection.
 
 ### Coverage
 **Example user requests:**

--- a/kiro-power/POWER.md
+++ b/kiro-power/POWER.md
@@ -12,11 +12,11 @@ author: "Sonar"
 
 Integrate with SonarQube Server or Cloud. This power provides seamless access to SonarQube's comprehensive code analysis platform, enabling you to detect bugs, security vulnerabilities, dependency risks, code smells, and enforce quality standards throughout your development workflow.
 
-SonarQube supports 30+ programming languages and provides actionable insights to help teams write cleaner, safer, and more maintainable code. Use it to analyze code snippets on-the-fly, search for issues, track quality metrics, and ensure your projects meet quality gate standards before deployment.
+SonarQube supports 30+ programming languages and provides actionable insights to help teams write cleaner, safer, and more maintainable code. Use it to analyze files on-the-fly with Vortex analysis, search for issues, track quality metrics, and ensure your projects meet quality gate standards before deployment.
 
 **Key capabilities:**
 
-- **Code Analysis**: Analyze code snippets and files directly within your development context
+- **Code Analysis**: Analyze files directly within your development context
 - **Issue Management**: Search, filter, and manage code quality issues across projects
 - **Quality Gates**: Monitor and enforce quality standards before deployment
 - **Security Scanning**: Detect security vulnerabilities and hotspots
@@ -66,29 +66,28 @@ Always resolve the project key using the following lookup order — **never gues
 
 ### Code Analysis
 
-**Always provide complete file content for accurate analysis:**
+**Prefer Vortex analysis** (`run_advanced_code_analysis`) when the connected organization is eligible — it runs server-side with full project context for deeper cross-file detection:
 
 ```javascript
-// Analyze entire file - reports all issues
-analyze_code_snippet({
-    fileContent: `import { Item } from './types';\n\nfunction calculateTotal(items: Item[]) { ... }`,
-    language: "typescript",
-    projectKey: "my-project"
-});
-
-// Analyze with snippet filter (RECOMMENDED for generated code)
-// Analyzes complete file but only reports issues in the snippet
-analyze_code_snippet({
-    fileContent: `import { Item } from './types';\n\nfunction calculateTotal(items: Item[]) { return items.reduce((sum, item) => sum + item.price, 0); }`,
-    codeSnippet: "function calculateTotal(items: Item[]) { return items.reduce((sum, item) => sum + item.price, 0); }",
-    language: "typescript",
-    projectKey: "my-project"
+// Analyze a single file with Vortex
+run_advanced_code_analysis({
+    projectKey: "my-project",
+    branchName: "main",
+    filePath: "src/utils.ts",
+    fileScope: "MAIN"
 });
 ```
 
-**Supported Languages for Local Code Snippet Analysis:**
+- `fileContent` is optional — only pass it if the file isn't already accessible to the MCP server (e.g. no workspace mount configured).
+- `fileScope` is `"MAIN"` or `"TEST"`.
 
-The `analyze_code_snippet` tool supports the following languages: Java, Kotlin, Python, Ruby, Go, JavaScript, TypeScript, JSP, PHP, XML, HTML, CSS, CloudFormation, Kubernetes, Terraform, Azure Resource Manager, Ansible, Docker, Secrets detection
+**If the organization isn't Vortex-eligible, fall back to `analyze_file_list`** — this requires a running SonarQube for IDE instance bridged to the session:
+
+```javascript
+analyze_file_list({
+    file_absolute_paths: ["/workspace/src/utils.ts"]
+});
+```
 
 ### Issue Management
 
@@ -178,29 +177,20 @@ sonar run mcp --read-only
 ### Workflow 1: Analyze Generated Code Before Using It
 
 ```javascript
-// Step 1: Agent reads the existing file
-const originalContent = readFile("/workspace/src/utils.js");
+// Step 1: Agent generates a new method and writes it to the file
+writeFile("/workspace/src/utils.js", updatedContent);
 
-// Step 2: Agent generates a new method
-const newMethod = `
-function calculateTotal(items) {
-  return items.reduce((sum, item) => sum + item.price, 0);
-}`;
-
-// Step 3: Agent creates updated content with the new method
-const updatedContent = originalContent + "\n" + newMethod;
-
-// Step 4: Analyze just the generated method with full file context
-const analysis = analyze_code_snippet({
-    fileContent: updatedContent,
-    codeSnippet: newMethod,
-    language: "javascript",
-    projectKey: "my-project"
+// Step 2: Analyze the file with Vortex
+const analysis = run_advanced_code_analysis({
+    projectKey: "my-project",
+    branchName: "main",
+    filePath: "src/utils.js",
+    fileScope: "MAIN"
 });
 
-// Step 5: Review detected issues
-// Step 6: Fix issues in your code
-// Step 7: Re-analyze to verify fixes
+// Step 3: Review detected issues
+// Step 4: Fix issues in your code
+// Step 5: Re-analyze to verify fixes
 ```
 
 ### Workflow 2: Review Issues in Pull Request
@@ -371,20 +361,20 @@ const risks = get_file_coverage_details({
 4. For branches/PRs, ensure they've been analyzed
 5. Review project settings in SonarQube dashboard
 
-### Code snippet analysis fails
+### Code analysis fails
 
-**Cause:** Language not supported or analysis error
+**Cause:** Organization not Vortex-eligible, SonarQube for IDE not running, or analysis error
 **Solution:**
 
-1. Specify correct language parameter
-2. Check code snippet is valid syntax
-3. Provide project key for better context
+1. If `run_advanced_code_analysis` is unavailable, notify the user that it's not possible without Vortex eligibility
+2. If falling back to `analyze_file_list`, notify the user that it's not possible without setting up the bridge to SonarQube for IDE
+3. Provide the correct project key for better context
 4. Review MCP server logs at `/app/storage/logs/mcp.log` in the container
 
 ## Tips
 
 1. **Start with project discovery** - Use `search_my_sonarqube_projects` to find available projects
-2. **Analyze code snippets frequently** - Catch issues early in development
+2. **Analyze files frequently** - Catch issues early in development
 3. **Review rule details** - Understand why issues are flagged and how to fix them
 4. **Monitor trends, not just values** - Track if metrics are improving or degrading over time
 5. **Use selective toolsets** - Enable only what you need to reduce context overhead

--- a/rules/sonarqube.md
+++ b/rules/sonarqube.md
@@ -44,13 +44,13 @@ Invoke the `sonar-integrate` skill when another skill surfaces a failure that po
 
 **What to do:** Invoke the `sonar-list-issues` skill end-to-end. It supports filtering by severity, type, status, rule, tag, component, branch, and pull request, and always passes `-p <project-key>` to the CLI.
 
-### Code Snippet Analysis
+### Code Analysis
 **Example user requests:**
-- "Analyze this code snippet for issues"
+- "Analyze this code for issues"
 - "Check this code for quality problems"
 - "Generate a method that does X and analyze it for issues"
 
-**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex analysis) and falls back to `mcp__sonarqube__analyze_code_snippet`, handling file reading, language detection, and scope selection.
+**What to do:** Invoke the `sonar-analyze` skill end-to-end. It prefers `mcp__sonarqube__run_advanced_code_analysis` (Vortex analysis) and falls back to `mcp__sonarqube__analyze_file_list`, handling file reading and scope selection.
 
 ### Coverage
 **Example user requests:**

--- a/skills/sonar-analyze/SKILL.md
+++ b/skills/sonar-analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sonar-analyze
-description: Analyze a file or code snippet for quality and security issues using SonarQube
+description: Analyze a file for quality and security issues using SonarQube
 argument-hint: "[file-path]"
 allowed-tools: Read, Glob, Bash(git branch:*), Bash(docker ps:*), Bash(podman ps:*), Bash(nerdctl ps:*), Bash(sonar:*)
 ---
@@ -18,7 +18,7 @@ sonar-analyze src/auth/login.py      # analyze a specific file
 
 ## Prerequisites
 
-This skill requires the SonarQube MCP Server to be configured and at least one of the tools `mcp__sonarqube__run_advanced_code_analysis`, `mcp__sonarqube__analyze_code_snippet`, or `mcp__sonarqube__analyze_file_list` to be available in your session.
+This skill requires the SonarQube MCP Server to be configured and at least one of the tools `mcp__sonarqube__run_advanced_code_analysis` or `mcp__sonarqube__analyze_file_list` to be available in your session.
 
 **Before proceeding**, verify at least one of these tools is accessible. If none are, try the CLI fallback in Step 3 before giving up — don't invent other CLI commands (e.g. `sonar mcp call` does not exist).
 
@@ -51,26 +51,10 @@ Both analysis tools work on **one file at a time**. Resolve a single file path:
 
 Do not accept a directory as input. If the user provides one, ask them to specify a single file.
 
-### Step 2: Read the file and detect context
+### Step 2: Read the file and determine its scope
 
-1. Read the file's full content (needed for the fallback tool and language detection).
-2. Detect the language from the file extension (needed for the standard tool):
-
-| Extension              | Language key |
-| ---------------------- | ------------ |
-| `.py`                  | `py`         |
-| `.js` `.jsx`           | `js`         |
-| `.ts` `.tsx`           | `ts`         |
-| `.java`                | `java`       |
-| `.go`                  | `go`         |
-| `.php`                 | `php`        |
-| `.cs`                  | `cs`         |
-| `.rb`                  | `rb`         |
-| `.swift`               | `swift`      |
-| `.kt`                  | `kotlin`     |
-| `.c` `.cpp` `.cc` `.h` | `cpp`        |
-
-3. Determine the file scope: `"TEST"` or `"MAIN"`. Use the file path to deduce the scope. For example, if the file path contains `test`, `spec`, or `__tests__`, it's likely `"TEST"` scope.
+1. Read the file's full content — only needed as a fallback for `run_advanced_code_analysis`'s `fileContent` parameter (see Step 3).
+2. Determine the file scope: `"TEST"` or `"MAIN"`. Use the file path to deduce the scope. For example, if the file path contains `test`, `spec`, or `__tests__`, it's likely `"TEST"` scope.
 
 ### Step 3: Call the appropriate analysis tool
 
@@ -90,21 +74,17 @@ Then call with:
 - `fileContent` — full file content; **only pass if the tool requires it** (when the MCP server has a mount, it reads the file directly and this parameter will not be required)
 - `fileScope` — `["TEST"]` or `["MAIN"]`
 
-**If that tool is unavailable, fall back to `mcp__sonarqube__analyze_code_snippet` or `mcp__sonarqube__analyze_file_list`** (available for all organizations):
+**If that tool is unavailable, fall back to `mcp__sonarqube__analyze_file_list`** (requires a running SonarQube for IDE instance bridged to this session):
 
-- `projectKey` — **omit unless the tool requires it**; resolve the same way as above when needed
-- `filePath` — project-relative file path (e.g. `src/auth/login.py`)
-- `codeSnippet` — full file content (optional; provide to narrow analysis to a specific snippet)
-- `language` — detected language key
-- `scope` — `"TEST"` or `"MAIN"`
+- `file_absolute_paths` — array containing the absolute path to the file (e.g. `["/home/user/project/src/auth/login.py"]`); resolve it from the file path found in Step 1
 
-**If none of the three MCP tools are available, fall back to the CLI's Vortex analysis:**
+**If neither MCP tool is available, fall back to the CLI's Vortex analysis:**
 
 ```bash
 sonar analyze agentic --file <file-path> [--file <other-file-path> ...] --format json [--branch <branch-name>] [-p <project-key>]
 ```
 
-Same backend as `run_advanced_code_analysis` (repeatable `--file` covers multi-file too), and the practical fallback for `analyze_code_snippet`/`analyze_file_list` as well — they have no direct CLI equivalent, but this achieves the same goal.
+Same backend as `run_advanced_code_analysis` (repeatable `--file` covers multi-file too), and the practical fallback for `analyze_file_list` as well — it has no direct CLI equivalent, but this achieves the same goal.
 
 Requires a Vortex analysis-eligible organization. If the org isn't eligible, or `sonar` isn't installed/authenticated, show the standard message from Prerequisites — don't guess further commands.
 


### PR DESCRIPTION
----
## Summary by Gitar

- **MCP Tool Updates:**
    - Removed references to `analyze_code_snippet` in favor of `run_advanced_code_analysis` and `analyze_file_list` across skill documentation and rules (`skills/sonar-analyze/SKILL.md`, `kiro-power/POWER.md`, `GEMINI.md`, `rules/sonarqube.md`)

<sub>This will update automatically on new commits.</sub>